### PR TITLE
feat: Datatable layout and export for User Management

### DIFF
--- a/accounts/templates/accounts/user_management.html
+++ b/accounts/templates/accounts/user_management.html
@@ -32,9 +32,10 @@
     </div>
     
     <div class="table-responsive">
-        <table class="table table-striped">
+        <table cellpadding="1" cellspacing="2" border="0" class="table table-striped table-bordered dataTable" id="usersTable" width="100%">
             <thead>
                 <tr>
+                    <th>Sr No</th>
                     <th>Username</th>
                     <th>Name</th>
                     <th>Groups</th>
@@ -46,15 +47,15 @@
             </thead>
             <tbody>
                 {% for user in users %}
+                {% if user.is_active %}
                 {% with profile=user.mongo_profile %}
                 <tr>
+                    <td>{{ forloop.counter }}</td>
                     <td>{{ user.username }}</td>
                     <td>{{ user.get_full_name }}</td>
                     <td>
                         {% if profile.groups %}
-                            {% for group in profile.groups %}
-                                <span class="badge badge-info group-badge">{{ group }}</span>
-                            {% endfor %}
+                            {% for group in profile.groups %}<span class="badge badge-info group-badge">{{ group }}</span> {% endfor %}
                         {% else %}
                             -
                         {% endif %}
@@ -76,8 +77,91 @@
                     </td>
                 </tr>
                 {% endwith %}
+                {% endif %}
                 {% endfor %}
             </tbody>
+            <tfoot>
+                <tr>
+                    <th>Sr No</th>
+                    <th>Username</th>
+                    <th>Name</th>
+                    <th>Groups</th>
+                    <th>Area</th>
+                    <th>Designation</th>
+                    <th>Status</th>
+                    <th>Actions</th>
+                </tr>
+            </tfoot>
+        </table>
+    </div>
+
+    <div class="row mb-3 mt-4">
+        <div class="col-md-12">
+            <h4>Inactive Users</h4>
+        </div>
+    </div>
+    
+    <div class="table-responsive">
+        <table cellpadding="1" cellspacing="2" border="0" class="table table-striped table-bordered dataTable" id="inactiveUsersTable" width="100%">
+            <thead>
+                <tr>
+                    <th>Sr No</th>
+                    <th>Username</th>
+                    <th>Name</th>
+                    <th>Groups</th>
+                    <th>Area</th>
+                    <th>Designation</th>
+                    <th>Status</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for user in users %}
+                {% if not user.is_active %}
+                {% with profile=user.mongo_profile %}
+                <tr>
+                    <td>{{ forloop.counter }}</td>
+                    <td>{{ user.username }}</td>
+                    <td>{{ user.get_full_name }}</td>
+                    <td>
+                        {% if profile.groups %}
+                            {% for group in profile.groups %}<span class="badge badge-info group-badge">{{ group }}</span> {% endfor %}
+                        {% else %}
+                            -
+                        {% endif %}
+                    </td>
+                    <td>{{ profile.area|default:"-" }}</td>
+                    <td>{{ profile.designation|default:"-" }}</td>
+                    <td>
+                        {% if user.is_active %}
+                        <span class="badge badge-success">Active</span>
+                        {% else %}
+                        <span class="badge badge-danger">Inactive</span>
+                        {% endif %}
+                    </td>
+                    <td>
+                        <a href="{% url 'edit_user' user.id %}" class="btn btn-sm btn-info">Edit</a>
+                        {% if not user.is_superuser %}
+                        <button class="btn btn-sm btn-danger delete-user" data-userid="{{ user.id }}" data-username="{{ user.username }}">Delete</button>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endwith %}
+                {% endif %}
+                {% endfor %}
+            </tbody>
+            <tfoot>
+                <tr>
+                    <th>Sr No</th>
+                    <th>Username</th>
+                    <th>Name</th>
+                    <th>Groups</th>
+                    <th>Area</th>
+                    <th>Designation</th>
+                    <th>Status</th>
+                    <th>Actions</th>
+                </tr>
+            </tfoot>
         </table>
     </div>
 </div>
@@ -169,5 +253,33 @@
             $(this).remove(); 
         });
     }, 5000);
+
+    $(document).ready(function() {
+        var commonSettings = {
+            dom: 'Bfrtip',
+            lengthMenu: [[10,25,50,100,-1],[10,25,50,100,"All"]],
+            scrollX: true
+        };
+
+        $('#usersTable').DataTable($.extend(true, {}, commonSettings, {
+            buttons: [{
+                extend: 'excel',
+                title: 'Active_Users'
+            },
+            {
+                extend: 'pageLength',
+            }]
+        }));
+
+        $('#inactiveUsersTable').DataTable($.extend(true, {}, commonSettings, {
+            buttons: [{
+                extend: 'excel',
+                title: 'Inactive_Users'
+            },
+            {
+                extend: 'pageLength',
+            }]
+        }));
+    });
 </script>
 {% endblock %} 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -38,8 +38,8 @@ def login_view(request):
 
 @permission_required('accounts', 'view')
 def user_management(request):
-    # Get all users except the current user and not active user
-    users = User.objects.filter(is_active=True).exclude(id=request.user.id)
+    # Get all users except the current user
+    users = User.objects.all().exclude(id=request.user.id)
     
     # Attach MongoDB profiles to users
     for user in users:


### PR DESCRIPTION
### Summary
This PR replaces the old, basic HTML table on the User Management page with a new, stylized layout utilizing Datatables with Excel Export capabilities. 

### Changes Made
- Transformed the User Management table into two separate stacked tables: **Active Users** and **Inactive Users**.
- Added DataTables JavaScript components for filtering, sorting, and pagination on both tables.
- Provided an **Excel Export Button** to both tables to download users instantly as spreadsheets.
- Updated `user_management(request)` in `accounts/views.py` to lift the `is_active=True` filter so inactive users are correctly collected and sent to the frontend template.

### Impact
Improves the User Management module interface to match the sleek design and export capabilities already implemented for the `IT_Return` module. Admin users can now filter active and inactive users separately with properly enumerated row numbers (Sr No).