### PR TITLE
feat: Add Mandatory Timesheet Management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ coverage.xml
 
 # Local development settings
 local_settings.py
+
+# DB Files
+db.sqlite3

--- a/accounts/database.py
+++ b/accounts/database.py
@@ -22,12 +22,16 @@ def get_all_groups():
 
 def create_user_profile_mongo(user_data):
     """Create user profile in MongoDB"""
+    role = user_data.get('role', '')
+    timesheet_mandatory = role not in ['Super Admin', 'Super Group Head', 'Group Head']
+    
     profile_data = {
         "django_user_id": str(user_data['user'].id),
         "area": user_data.get('area', ''),
         "groups": user_data.get('groups', []),  # Store as array
         "designation": user_data.get('designation', ''),
-        "role": user_data.get('role', ''),
+        "role": role,
+        "timesheet_mandatory": timesheet_mandatory,
         "time_in": user_data.get('time_in'),
         "time_out": user_data.get('time_out'),
         "effective_date": user_data.get('effective_date'),
@@ -214,3 +218,18 @@ def get_group_members(user_id):
     except Exception as e:
         print(f"Error fetching group members: {str(e)}")
         return [] 
+
+def is_timesheet_mandatory(user_profile):
+    """Check if timesheet is mandatory for a user based on profile or default role logic."""
+    if 'timesheet_mandatory' in user_profile:
+        return user_profile['timesheet_mandatory']
+    # Fallback default if field missing
+    role = user_profile.get('role', '')
+    return role not in ['Super Admin', 'Super Group Head', 'Group Head']
+
+def update_timesheet_mandatory_status(django_user_id, status: bool):
+    """Update timesheet mandatory status in MongoDB"""
+    return db.userProfiles.update_one(
+        {"django_user_id": str(django_user_id)},
+        {"$set": {"timesheet_mandatory": status, "updated_at": datetime.now()}}
+    )

--- a/accounts/roles.py
+++ b/accounts/roles.py
@@ -94,4 +94,13 @@ ROLE_PERMISSIONS = {
             # Note: No access to reports and accounts
         }
     }
-} 
+}
+
+# Role hierarchy (lower number indicates higher authority)
+ROLE_HIERARCHY = {
+    'Super Admin': 1,
+    'Super Group Head': 2,
+    'Group Head': 3,
+    'Senior Staff': 4,
+    'Trainee': 5
+}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -27,6 +27,12 @@
 	<link href="{% static 'assets/css/bootstrap-icons-1.5.0/bootstrap-icons.css' %}" rel="stylesheet" type="text/css">
 
 	<style>
+		.profile-dropdown {
+			min-width: 220px !important;
+		}
+		.profile-dropdown .dropdown-item {
+			white-space: nowrap;
+		}
 		.has-error .bootstrap-select .dropdown-toggle {
 			border-color: #dc3545 !important;
 			box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25) !important;
@@ -104,6 +110,10 @@
 								<!-- Menu Items -->
 									<a class="dropdown-item" href="{% url 'user_management' %}">
 										<i class="fe-users mr-1"></i> User Management
+									</a>
+									
+									<a class="dropdown-item" href="{% url 'manage_mandatory_timesheets' %}">
+										<i class="fe-clock mr-1"></i> Manage Timesheets
 									</a>
 									
 									<div class="dropdown-divider"></div>

--- a/timesheet/templates/manage_mandatory_timesheets.html
+++ b/timesheet/templates/manage_mandatory_timesheets.html
@@ -1,0 +1,97 @@
+{% extends "layout.html" %}
+{% block head_block %}
+    <title>HMD | Manage Mandatory Timesheets</title>
+{% endblock %}
+{% block body_block %}
+<div class="container-fluid">
+    <div class="row mb-3">
+        <div class="col-md-12">
+            <h4>Manage Mandatory Timesheets</h4>
+            <p class="text-muted">Toggle the timesheet 7-day restriction policy for the users below.</p>
+        </div>
+    </div>
+    
+    <div class="table-responsive">
+        <table cellpadding="1" cellspacing="2" border="0" class="table table-striped table-bordered dataTable" id="mandatoryTable" width="100%">
+            <thead>
+                <tr>
+                    <th>Sr No</th>
+                    <th>Name</th>
+                    <th>Username</th>
+                    <th>Role</th>
+                    <th>Timesheet Mandatory</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for user in users %}
+                <tr>
+                    <td>{{ forloop.counter }}</td>
+                    <td>{{ user.name }}</td>
+                    <td>{{ user.username }}</td>
+                    <td>{{ user.role }}</td>
+                    <td>
+                        <div class="custom-control custom-switch">
+                            <input type="checkbox" class="custom-control-input mandatory-toggle" 
+                                id="toggle_{{ user.id }}" 
+                                data-userid="{{ user.id }}"
+                                {% if user.timesheet_mandatory %}checked{% endif %}>
+                            <label class="custom-control-label" for="toggle_{{ user.id }}"></label>
+                        </div>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        // Init DataTable
+        var commonSettings = {
+            dom: 'Bfrtip',
+            lengthMenu: [[10,25,50,-1],[10,25,50,"All"]],
+            scrollX: true,
+            buttons: [
+                {
+                    extend: 'excel',
+                    title: 'Mandatory_Timesheets'
+                },
+                {
+                    extend: 'pageLength',
+                }
+            ]
+        };
+        $('#mandatoryTable').DataTable(commonSettings);
+
+        // Handle toggle
+        $('.mandatory-toggle').change(function() {
+            var userId = $(this).data('userid');
+            var status = $(this).is(':checked');
+            
+            $.ajax({
+                url: '{% url "manage_mandatory_timesheets" %}',
+                type: 'POST',
+                data: {
+                    'user_id': userId,
+                    'status': status,
+                    'csrfmiddlewaretoken': '{{ csrf_token }}'
+                },
+                success: function(response) {
+                    if (response.status === 'success') {
+                        // Optional: show a small toast or notification
+                    } else {
+                        alert('Error updating status: ' + (response.message || 'Unknown error'));
+                        // Revert toggle
+                        $('#toggle_' + userId).prop('checked', !status);
+                    }
+                },
+                error: function(xhr) {
+                    alert('Error updating status');
+                    $('#toggle_' + userId).prop('checked', !status);
+                }
+            });
+        });
+    });
+</script>
+{% endblock %}

--- a/timesheet/urls.py
+++ b/timesheet/urls.py
@@ -8,5 +8,6 @@ urlpatterns = [
     path('employee-corner/', views.employee_corner, name='employee_corner'),
     path('get-time-settings/', views.get_time_settings, name='get_time_settings'),
     path('delete-entry/', views.delete_timesheet_entry, name='delete_timesheet_entry'),
-    path('get_pending_entries/', views.get_pending_entries, name='get_pending_entries')
+    path('get_pending_entries/', views.get_pending_entries, name='get_pending_entries'),
+    path('manage-mandatory-timesheets/', views.manage_mandatory_timesheets, name='manage_mandatory_timesheets')
 ]

--- a/timesheet/views.py
+++ b/timesheet/views.py
@@ -7,8 +7,10 @@ from django.contrib.auth import get_user_model
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import JsonResponse, HttpRequest
 from django.shortcuts import render, redirect
+from django.db.models import Q
 
-from accounts.database import get_user_profile_mongo, get_group_members
+from accounts.database import get_user_profile_mongo, get_group_members, is_timesheet_mandatory, update_timesheet_mandatory_status
+from accounts.roles import ROLE_HIERARCHY
 from accounts.decorators import permission_required
 from .database import (
     get_user_first_effective_date,
@@ -71,6 +73,45 @@ def fill_timesheet(request: HttpRequest):
 
         reason = request.POST.get('reason', '').upper()
         
+        # Check for pending timesheets from previous 7 days
+        user_profile = get_user_profile_mongo(request.user.id)
+        if not user_profile:
+            messages.error(request, 'User profile not found. Please contact administrator.')
+            return redirect('fill_timesheet')
+
+        if is_timesheet_mandatory(user_profile):
+            user_start_date = user_profile.get('effective_date')
+            days_checked = 0
+            days_with_pending = 0
+            check_date = today - timedelta(days=1)
+            
+            # Only check previous days if we're entering for today
+            if entry_date == today:
+                while days_checked < 7:
+                    # Stop checking if we hit the user's start date
+                    if user_start_date and check_date < user_start_date:
+                        break
+                        
+                    if check_date.weekday() != 6:  # Not Sunday
+                        daily_entries = get_user_timesheets(request.user.id, check_date)
+                        if daily_entries:
+                            # Check if the last entry of the day has pending_hours set to 0
+                            last_entry = daily_entries[0]  # get_user_timesheets returns sorted by created_at desc
+                            if last_entry.get('pending_hours', 0) - last_entry.get('hours', 0) > 0:  # If pending_hours is not 0
+                                days_with_pending += 1
+                        else:
+                            # If no entries exist for the day, consider it as pending
+                            days_with_pending += 1
+                    days_checked += 1
+                    check_date -= timedelta(days=1)
+                    
+                if days_with_pending > 0:
+                    messages.error(
+                        request,
+                        f'You cannot fill out a timesheet. You have pending hours for {days_with_pending} of the last 7 days.'
+                    )
+                    return redirect('fill_timesheet')
+
         # Check if pending hours are negative
         if pending_hours < 0:
             messages.error(request, 'Cannot submit timesheet when pending hours are negative')
@@ -480,3 +521,63 @@ def delete_timesheet_entry(request: HttpRequest) -> JsonResponse:
         },
         status=405
     )
+
+@permission_required('timesheet', 'view')
+def manage_mandatory_timesheets(request: HttpRequest):
+    """View to allow higher roles to mark lower roles as timesheet_mandatory True/False"""
+    if request.method == 'POST':
+        target_user_id = request.POST.get('user_id')
+        status = request.POST.get('status') == 'true'
+        
+        # Verify permissions
+        current_profile = get_user_profile_mongo(request.user.id)
+        current_role = current_profile.get('role', '') if current_profile else ''
+        current_rank = ROLE_HIERARCHY.get(current_role, 99)
+        
+        if is_admin(request.user):
+            current_rank = 0
+            
+        target_profile = get_user_profile_mongo(target_user_id)
+        if not target_profile:
+            return JsonResponse({'status': 'error', 'message': 'User profile not found'}, status=404)
+        
+        target_role = target_profile.get('role', '')
+        target_rank = ROLE_HIERARCHY.get(target_role, 99)
+        
+        if current_rank >= target_rank:
+            return JsonResponse({'status': 'error', 'message': 'Permission denied'}, status=403)
+            
+        update_timesheet_mandatory_status(target_user_id, status)
+        return JsonResponse({'status': 'success'})
+
+    # GET request
+    current_profile = get_user_profile_mongo(request.user.id)
+    current_role = current_profile.get('role', '') if current_profile else ''
+    current_rank = ROLE_HIERARCHY.get(current_role, 99)
+    
+    if is_admin(request.user):
+        current_rank = 0  # Can see everyone
+        
+    User = get_user_model()
+    # Exclude admins/superusers and current user
+    all_active_users = User.objects.filter(is_active=True).exclude(
+        groups__name__in=['Super Admin', 'Admin']
+    ).exclude(id=request.user.id)
+    
+    manageable_users = []
+    for u in all_active_users:
+        profile = get_user_profile_mongo(u.id)
+        if not profile:
+            continue
+        role = profile.get('role', '')
+        rank = ROLE_HIERARCHY.get(role, 99)
+        if rank > current_rank:
+            manageable_users.append({
+                'id': u.id,
+                'name': f"{u.first_name} {u.last_name}",
+                'username': u.username,
+                'role': role,
+                'timesheet_mandatory': is_timesheet_mandatory(profile)
+            })
+            
+    return render(request, 'manage_mandatory_timesheets.html', {'users': manageable_users, 'current_role': current_role})


### PR DESCRIPTION
## Summary

Adds a new **Manage Mandatory Timesheets** feature that allows higher-role users (e.g., Partners, Managers) to designate specific lower-role users as having mandatory timesheet compliance. When a user is flagged as mandatory, the 7-day pending timesheet restriction is enforced for them; otherwise, they can fill out timesheets freely.

## Changes Made

### Backend
- **accounts/database.py** — Added `update_timesheet_mandatory_status()` and `is_timesheet_mandatory()` helper functions for reading/writing the `timesheet_mandatory` flag in MongoDB user profiles.
- **accounts/roles.py** — Exposed `ROLE_HIERARCHY` dictionary so role-based permission checks can compare ranks between users.
- **timesheet/views.py** — Added `manage_mandatory_timesheets` view with GET (render page) and POST (toggle status via AJAX) handlers. Updated `fill_timesheet` POST logic to conditionally enforce the 7-day pending check only when `timesheet_mandatory` is True for the user.
- **timesheet/urls.py** — Added URL route for the new management page.

### Frontend
- **timesheet/templates/manage_mandatory_timesheets.html** — New page with a DataTable listing manageable users with toggle switches to enable/disable mandatory timesheet status per user.
- **templates/layout.html** — Added "Manage Timesheets" link in the profile dropdown menu. Fixed dropdown overflow issue by adding `min-width` and `white-space: nowrap` CSS to `.profile-dropdown`.

### Misc
- **.gitignore** — Added `db.sqlite3` to prevent committing the local SQLite database.

## Impact

- **No breaking changes** — Existing users default to `timesheet_mandatory: False`, so the 7-day restriction is not enforced unless explicitly toggled on by a higher-role user.
- **Role-based access control** — Only users with a higher role rank can toggle the mandatory flag for lower-rank users.
- **UI improvement** — The profile dropdown no longer clips the "Manage Timesheets" text.