### PR TITLE
feat: Revamp dashboard filters & add Closure Due Date to event landing

### DIFF
--- a/IT_Return/templates/landing.html
+++ b/IT_Return/templates/landing.html
@@ -68,8 +68,10 @@
             <h4 class="text-center header-title mb-3" style="width: 150%">LIVE BOARD</h4>
             <div class="card scroll" style="width: 150%"><br>
                 <div class="col-md-12"><br>
-                    <div class="form-group row">
+                    <!-- Row 1: Proceeding Type + From Date + To Date -->
+                    <div class="form-group row align-items-end mb-2">
                         <div class="col-md-6">
+                            <label class="mb-1" style="font-size:12px;font-weight:600;">Proceeding Type</label>
                             <select class="selectpicker form-control" id="proceedingsFilter"
                                     multiple
                                     data-live-search="true"
@@ -81,32 +83,30 @@
                                 {% endfor %}
                             </select>
                         </div>
-                        <div class="col-md-2">
-                            <button class="btn btn-block" style="background-color:DodgerBlue; color:white" onclick="filterProceedings()">Filter</button>
-                        </div>
-                        <div class="col-md-2">
-                            <button class="btn btn-block" style="background-color:DodgerBlue; color:white" onclick="printCertificate()">Print</button>
-                        </div>
-                    </div>
-                    <div class="form-group row align-items-end mt-1">
                         <div class="col-md-3">
                             <label class="mb-1" style="font-size:12px;font-weight:600;">From Date</label>
-                            <input type="date" id="dateFrom" class="form-control form-control-sm">
+                            <input type="date" id="dateFrom" class="form-control form-control-sm" onchange="filterProceedings()">
                         </div>
                         <div class="col-md-3">
                             <label class="mb-1" style="font-size:12px;font-weight:600;">To Date</label>
-                            <input type="date" id="dateTo" class="form-control form-control-sm">
-                        </div>
-                        <div class="col-md-3">
-                            <button class="btn btn-sm btn-secondary btn-block" onclick="clearDateFilter()" title="Clear date filter">
-                                <i class="fe-x"></i> Clear Dates
-                            </button>
+                            <input type="date" id="dateTo" class="form-control form-control-sm" onchange="filterProceedings()">
                         </div>
                     </div>
-                    <div class="form-group row">
-                        <div class="col-md-12">
-                            <button class="btn btn-block" id="markedCasesBtn" style="background-color:DodgerBlue; color:white" onclick="toggleMarkedCases()">
+                    <!-- Row 2: Action buttons inline -->
+                    <div class="form-group row mb-2">
+                        <div class="col-md-6">
+                            <button class="btn btn-sm btn-block" id="markedCasesBtn" style="background-color:DodgerBlue; color:white" onclick="toggleMarkedCases()">
                                 <i class="fas fa-star"></i> My Cases Only
+                            </button>
+                        </div>
+                        <div class="col-md-3">
+                            <button class="btn btn-sm btn-block" style="background-color:DodgerBlue; color:white" onclick="printCertificate()">
+                                <i class="fe-printer"></i> Print
+                            </button>
+                        </div>
+                        <div class="col-md-3">
+                            <button class="btn btn-sm btn-block btn-secondary" onclick="resetAllFilters()" title="Reset all filters">
+                                <i class="fe-refresh-cw"></i> Reset
                             </button>
                         </div>
                     </div>
@@ -115,7 +115,7 @@
                     <h4 id="filter_selected" style="display:none; text-align:center">ALL</h4>
                 <div class="card-body" id="proceeding_list">
                     {% for each_proc in Live_Board %}
-                    <a href="{% url 'Further Proc Info' id=each_proc|private:'_id' %}" data-closure-date="{{ each_proc.Closure_date|date:'Y-m-d' }}">
+                    <a href="{% url 'Further Proc Info' id=each_proc|private:'_id' %}" data-closure-date="{{ each_proc.Closure_date|date:'Y-m-d' }}" data-marked="{% if each_proc.is_marked %}true{% else %}false{% endif %}">
                         <p style="display:none" class="proceeding-description">{{ each_proc.Description }}</p>
                         <ul class="list-group list-group-horizontal" style="margin-bottom:5px" >
                             {% if each_proc.In_past == "Yes" %}
@@ -176,17 +176,8 @@
             btn.style.color = 'white';
         }
         
-        // Update URL to reflect the filter state
-        const url = new URL(window.location.href);
-        if (showMarkedOnly) {
-            url.searchParams.set('show_marked_only', 'true');
-        } else {
-            url.searchParams.delete('show_marked_only');
-        }
-        window.history.pushState({}, '', url);
-        
-        // Reload the page to get filtered data from server
-        window.location.href = url.toString();
+        // Re-apply all filters (no page reload)
+        filterProceedings();
     }
 
     function filterProceedings() {
@@ -213,20 +204,23 @@
                 if (dateTo)   dateMatch = dateMatch && (closureDateStr <= dateTo);
             }
 
-            $item.css('display', (typeMatch && dateMatch) ? 'block' : 'none');
+            // --- Marked-cases filter ---
+            var markedMatch = true;
+            if (showMarkedOnly) {
+                markedMatch = ($item.data('marked') === true || $item.data('marked') === 'true');
+            }
+
+            $item.css('display', (typeMatch && dateMatch && markedMatch) ? 'block' : 'none');
         });
 
         var label = noSelection ? 'ALL' : selectedValues.join(', ');
         if (dateFrom || dateTo) {
             label += ' \u2503 ' + (dateFrom || '...') + ' \u2192 ' + (dateTo || '...');
         }
+        if (showMarkedOnly) {
+            label += ' \u2503 My Cases';
+        }
         $('#filter_selected').text(label);
-    }
-
-    function clearDateFilter() {
-        $('#dateFrom').val('');
-        $('#dateTo').val('');
-        filterProceedings();
     }
 
     function printCertificate() {
@@ -242,9 +236,30 @@
         location.reload();
     }
 
+    function resetAllFilters() {
+        // Reset proceedings dropdown
+        $('#proceedingsFilter').selectpicker('deselectAll');
+        // Reset date fields
+        $('#dateFrom').val('');
+        $('#dateTo').val('');
+        // Reset marked cases
+        showMarkedOnly = false;
+        $('#markedCasesBtn').css({
+            'background-color': 'DodgerBlue',
+            'color': 'white'
+        });
+        // Re-apply (shows everything)
+        filterProceedings();
+    }
+
     $(document).ready( function () {
         // Initialize the multiselect proceedings filter
         $('#proceedingsFilter').selectpicker();
+
+        // Auto-apply filter when proceedings selection changes
+        $('#proceedingsFilter').on('changed.bs.select', function () {
+            filterProceedings();
+        });
 
         var modal_toggle = false;
         $('#it-return').on('click', function(event) {
@@ -299,15 +314,7 @@
             }
         });
 
-        // Initialize marked cases filter from URL
-        const urlParams = new URLSearchParams(window.location.search);
-        if (urlParams.get('show_marked_only') === 'true') {
-            showMarkedOnly = true;
-            $('#markedCasesBtn').css({
-                'background-color': '#ffc107',
-                'color': 'black'
-            });
-        }
+
     });
 </script>
 {% endblock %}

--- a/proceedings/database.py
+++ b/proceedings/database.py
@@ -174,6 +174,10 @@ def get_proc_for_event_details(r_id):
                 data['Actual_closure_date'] = date_to_IST_format(data['Actual_closure_date'])
             except:
                 data['Actual_closure_date'] = "-"
+            try:
+                data['Closure_due_date'] = date_to_IST_format(data['Closure_due_date'])
+            except:
+                data['Closure_due_date'] = "-"
 
         return result[0]
     else:

--- a/proceedings/templates/event_landing.html
+++ b/proceedings/templates/event_landing.html
@@ -67,9 +67,7 @@
 <th></th>
                                 <th align="left">Base Document: </th>
                                     <th align="left">Base Date: </th>
-                                
-                                
-                                <td></td>
+                                    <th align="left">Closure Due Date: </th>
                             </tr>
 <tr>
                                 <td>{{Data_Dict.Group_name}}</td>
@@ -78,7 +76,7 @@
                                 <td></td>
                                 <td>{{Data_Dict.Base_document}}</td>
                                 <td>{{Data_Dict.Base_date}}</td>
-                                <td></td>
+                                <td>{{Data_Dict.Closure_due_date}}</td>
                             </tr>
                             <tr>
                                 <td></td>


### PR DESCRIPTION
## Summary

This PR revamps the Live Board filter UI on the dashboard for a better user experience and adds the missing **Closure Due Date** field to the event landing page.

## Changes Made

### 1. Dashboard Live Board Filter Redesign (`IT_Return/templates/landing.html`)

**Layout restructured into two clean rows:**
- **Row 1:** Proceeding Type dropdown + From Date + To Date
- **Row 2:** My Cases Only | Print | Reset (clears all filters)

**Auto-apply filters (no button click needed):**
- Proceedings dropdown now auto-filters on selection change via `changed.bs.select` event
- Date pickers trigger filtering immediately via `onchange`
- Removed the old Filter apply button entirely

**Multiple filters work simultaneously:**
- Previously, activating one filter would reset others (e.g., My Cases Only triggered a page reload, wiping date/proceedings filters)
- Now all three filters (proceedings type, date range, marked cases) are applied together client-side
- My Cases Only no longer reloads the page — it toggles a client-side flag and re-filters in place

**Reset button:**
- Replaced the old Dates X button with a unified Reset button
- Clears proceedings selection, date fields, and marked-cases toggle in one click

### 2. Closure Due Date on Event Landing (`proceedings/templates/event_landing.html`)
- Added **Closure Due Date** column header and data cell to the case details table
- Displays `Data_Dict.Closure_due_date` alongside existing fields

### 3. Date Format Fix (`proceedings/database.py`)
- `Closure_due_date` was displaying in yyyy-mm-dd format while other dates showed dd-mm-yyyy
- Added `date_to_IST_format()` conversion for consistent formatting

## Impact

- **User Experience:** Filters are now instant and composable — no page reloads, no lost filter state
- **Data Visibility:** Closure Due Date is now visible on the event landing page
- **Consistency:** All dates across the event landing page now display in dd-mm-yyyy format