### PR TITLE
feat: lock client/task dropdowns to OFFICE WORK bidirectionally

### DIFF
--- a/timesheet/templates/fill_timesheet.html
+++ b/timesheet/templates/fill_timesheet.html
@@ -721,27 +721,55 @@ function fetchAssignments(clientName, taskType) {
         });
 }
 
-function toggleAssignmentFields() {
-    // Hide all assignment fields first
-    const assignmentFields = document.querySelectorAll('.assignment-field');
-    assignmentFields.forEach(field => {
+// Hide all dynamic assignment fields and clear any stored assignment value
+function hideAssignmentFields() {
+    document.querySelectorAll('.assignment-field').forEach(field => {
         field.style.display = 'none';
         const select = field.querySelector('select');
         if (select) {
             select.value = '';
+            select.required = false;
             if (select.classList.contains('selectpicker')) {
                 $(select).selectpicker('refresh');
             }
         }
-        if (select) select.required = false;
     });
+    document.getElementById('selected_assignment').value = '';
+    document.getElementById('selected_assignment_display').value = '';
+}
+
+function toggleAssignmentFields() {
+    // Hide all assignment fields first
+    hideAssignmentFields();
 
     // Show the relevant assignment field based on selected task
     const taskSelect = document.getElementById('task_select');
     const selectedTask = taskSelect.value;
     const clientSelect = document.querySelector('select[name="client_name"]');
+
+    // OFFICE WORK as the task locks the client dropdown to OFFICE WORK only.
+    // Setting the client value here is programmatic, so it does not re-fire the
+    // client change handler -- the task dropdown stays free as the escape hatch.
+    if (selectedTask === 'OFFICE WORK') {
+        Array.from(clientSelect.options).forEach(option => {
+            option.disabled = option.value !== 'OFFICE WORK';
+        });
+        clientSelect.value = 'OFFICE WORK';
+        $(clientSelect).selectpicker('refresh');
+        return;  // OFFICE WORK has no assignment to load
+    }
+
+    // Any other task releases the OFFICE WORK lock on the client dropdown.
+    Array.from(clientSelect.options).forEach(option => {
+        option.disabled = false;
+    });
+    if (clientSelect.value === 'OFFICE WORK') {
+        clientSelect.value = '';
+        $(clientSelect).selectpicker('refresh');
+    }
+
     const clientName = clientSelect.value;
-    
+
     if (selectedTask) {
         const assignmentField = document.getElementById(selectedTask + '_assignment');
         if (assignmentField) {
@@ -789,14 +817,17 @@ document.querySelector('select[name="client_name"]').addEventListener('change', 
     taskSelect.value = '';
     
     if (selectedClient === 'OFFICE WORK') {
-        // Disable all options except OFFICE WORK
+        // Disable all task options except OFFICE WORK and auto-select it
         Array.from(taskSelect.options).forEach(option => {
             if (option.value === 'OFFICE WORK') {
                 option.disabled = false;
+                option.selected = true;
             } else {
                 option.disabled = true;
             }
         });
+        // OFFICE WORK has no assignment; clear any stale assignment fields
+        hideAssignmentFields();
     } else if (selectedClient === 'LEAVE') {
         // Disable all options except LEAVE
         Array.from(taskSelect.options).forEach(option => {


### PR DESCRIPTION
## Summary

Tightens the OFFICE WORK handling on the **Fill Timesheet** form so the client and task dropdowns stay consistent no matter which side the user starts from.

## Behavior

- **Pick OFFICE WORK as the task** → all other client options are disabled and the client is pinned to `OFFICE WORK`. OFFICE WORK has no assignment, so the assignment fields are cleared and nothing is loaded.
- **Switch the task to anything else** → the OFFICE WORK lock on the client dropdown is released, and a stale `OFFICE WORK` client value is reset.
- **Pick OFFICE WORK as the client** → the OFFICE WORK task is auto-selected and any stale assignment fields are cleared.

The task dropdown remains the escape hatch: pinning the client is done programmatically, so it does not re-fire the client `change` handler.

## Refactor

Extracts the assignment-field reset logic into a shared `hideAssignmentFields()` helper (clears each `.assignment-field` select, unsets `required`, refreshes selectpicker, and clears the hidden `selected_assignment` / display inputs) so both the client and task code paths reuse it.

Touches only `timesheet/templates/fill_timesheet.html` (+38/−7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)