### PR TITLE
feat: mark timesheet days optional (Super Group Head / Super Admin)

### DIFF
--- a/accounts/database.py
+++ b/accounts/database.py
@@ -1,5 +1,5 @@
 import pymongo
-from datetime import datetime
+from datetime import datetime, timedelta
 from django.contrib.auth.models import User
 
 __MONGO_CONNECTION_URI__ = 'mongodb://localhost/'
@@ -23,8 +23,12 @@ def get_all_groups():
 def create_user_profile_mongo(user_data):
     """Create user profile in MongoDB"""
     role = user_data.get('role', '')
-    timesheet_mandatory = role not in ['Super Admin', 'Super Group Head', 'Group Head']
-    
+    # Explicit choice from the form wins; otherwise fall back to the role default.
+    timesheet_mandatory = user_data.get('timesheet_mandatory')
+    if timesheet_mandatory is None:
+        timesheet_mandatory = role not in ['Super Admin', 'Super Group Head', 'Group Head']
+
+    effective_date = user_data.get('effective_date')
     profile_data = {
         "django_user_id": str(user_data['user'].id),
         "area": user_data.get('area', ''),
@@ -32,15 +36,23 @@ def create_user_profile_mongo(user_data):
         "designation": user_data.get('designation', ''),
         "role": role,
         "timesheet_mandatory": timesheet_mandatory,
+        # Audit log of mandatory toggles, mirroring rate_history (newest at index 0).
+        "mandatory_history": [{
+            "mandatory": timesheet_mandatory,
+            "effective_date": effective_date or datetime.now().replace(hour=0, minute=0, second=0, microsecond=0),
+            "changed_by": user_data.get('changed_by'),
+            "changed_by_name": user_data.get('changed_by_name'),
+            "created_at": datetime.now(),
+        }],
         "time_in": user_data.get('time_in'),
         "time_out": user_data.get('time_out'),
-        "effective_date": user_data.get('effective_date'),
+        "effective_date": effective_date,
         "hourly_rate": float(user_data.get('hourly_rate', 0)) if user_data.get('hourly_rate') else None,
         "rate_history": user_data.get('rate_history', []),
         "created_at": datetime.now(),
         "updated_at": datetime.now()
     }
-    
+
     return db.userProfiles.insert_one(profile_data)
 
 def get_user_profile_mongo(django_user_id):
@@ -219,6 +231,11 @@ def get_group_members(user_id):
         print(f"Error fetching group members: {str(e)}")
         return [] 
 
+def get_users_by_role(role):
+    """Return django_user_ids of all userProfiles with the given role (e.g. 'Group Head')."""
+    profiles = db.userProfiles.find({'role': role}, {'_id': 0, 'django_user_id': 1})
+    return [profile['django_user_id'] for profile in profiles]
+
 def is_timesheet_mandatory(user_profile):
     """Check if timesheet is mandatory for a user based on profile or default role logic."""
     if 'timesheet_mandatory' in user_profile:
@@ -228,8 +245,83 @@ def is_timesheet_mandatory(user_profile):
     return role not in ['Super Admin', 'Super Group Head', 'Group Head']
 
 def update_timesheet_mandatory_status(django_user_id, status: bool):
-    """Update timesheet mandatory status in MongoDB"""
+    """Update timesheet mandatory status in MongoDB (boolean only, no history).
+
+    Prefer set_timesheet_mandatory() which also records the change in mandatory_history.
+    """
     return db.userProfiles.update_one(
         {"django_user_id": str(django_user_id)},
         {"$set": {"timesheet_mandatory": status, "updated_at": datetime.now()}}
     )
+
+
+def _normalize_day(d):
+    """Midnight datetime, matching how timesheet dates / effective_date are stored."""
+    return d.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _mandatory_on(history, day):
+    """Whether the timesheet was mandatory on `day` per a newest-first mandatory_history.
+
+    Returns the status of the most recent entry whose effective_date <= day; for days
+    before the earliest entry, falls back to the earliest entry's status (or True).
+    """
+    if not history:
+        return True
+    day = _normalize_day(day)
+    for entry in history:  # newest first
+        eff = entry.get('effective_date')
+        if eff and _normalize_day(eff) <= day:
+            return entry.get('mandatory', True)
+    return history[-1].get('mandatory', True)
+
+
+def get_non_mandatory_dates(profile, start, end):
+    """Set of working-day (Mon-Sat) midnights in [start, end] that fell in a non-mandatory period.
+
+    Driven by the user's mandatory_history; empty when the user has no history (so callers
+    fall back to plain optional-day handling). Lets the timesheet views treat non-mandatory
+    stretches as optional without stamping every future day.
+    """
+    history = profile.get('mandatory_history') if profile else None
+    if not history:
+        return set()
+    cur = _normalize_day(start)
+    end = _normalize_day(end)
+    result = set()
+    while cur <= end:
+        if cur.weekday() != 6 and not _mandatory_on(history, cur):  # skip Sundays
+            result.add(cur)
+        cur += timedelta(days=1)
+    return result
+
+
+def set_timesheet_mandatory(django_user_id, mandatory, changed_by=None, changed_by_name=None):
+    """Set a user's timesheet-mandatory status, appending to mandatory_history when it changes.
+
+    Mirrors the rate_history idiom: a new entry is inserted at index 0 only when the value
+    differs from the current head. Keeps the denormalized timesheet_mandatory boolean in sync.
+    Returns True if the status actually changed.
+    """
+    profile = get_user_profile_mongo(django_user_id)
+    history = (profile.get('mandatory_history', []) if profile else []) or []
+
+    changed = not history or history[0].get('mandatory') != mandatory
+    if changed:
+        history.insert(0, {
+            "mandatory": mandatory,
+            "effective_date": datetime.now().replace(hour=0, minute=0, second=0, microsecond=0),
+            "changed_by": str(changed_by) if changed_by else None,
+            "changed_by_name": changed_by_name,
+            "created_at": datetime.now(),
+        })
+
+    db.userProfiles.update_one(
+        {"django_user_id": str(django_user_id)},
+        {"$set": {
+            "timesheet_mandatory": mandatory,
+            "mandatory_history": history,
+            "updated_at": datetime.now(),
+        }},
+    )
+    return changed

--- a/accounts/database.py
+++ b/accounts/database.py
@@ -44,6 +44,15 @@ def create_user_profile_mongo(user_data):
             "changed_by_name": user_data.get('changed_by_name'),
             "created_at": datetime.now(),
         }],
+        # Account status: 'active' | 'hold' | 'inactive' (Django is_active == status=='active').
+        "status": user_data.get('status', 'active'),
+        "status_history": [{
+            "status": user_data.get('status', 'active'),
+            "effective_date": datetime.now().replace(hour=0, minute=0, second=0, microsecond=0),
+            "changed_by": user_data.get('changed_by'),
+            "changed_by_name": user_data.get('changed_by_name'),
+            "created_at": datetime.now(),
+        }],
         "time_in": user_data.get('time_in'),
         "time_out": user_data.get('time_out'),
         "effective_date": effective_date,
@@ -325,3 +334,45 @@ def set_timesheet_mandatory(django_user_id, mandatory, changed_by=None, changed_
         }},
     )
     return changed
+
+
+def get_user_status(profile):
+    """Effective account status of a profile: 'active' | 'hold' | 'inactive'.
+
+    Falls back for legacy profiles that predate the status field.
+    """
+    if profile and profile.get('status'):
+        return profile['status']
+    return 'active'
+
+
+def set_user_status(django_user_id, status, changed_by=None, changed_by_name=None):
+    """Set a user's account status, appending to status_history when it changes.
+
+    Mirrors the mandatory_history idiom (newest entry at index 0, only on change).
+    Updates the Mongo profile only; the caller flips the Django User.is_active flag.
+    Returns (changed, prev_status).
+    """
+    profile = get_user_profile_mongo(django_user_id)
+    history = (profile.get('status_history', []) if profile else []) or []
+    prev_status = history[0].get('status') if history else (profile.get('status') if profile else None)
+
+    changed = prev_status != status
+    if changed:
+        history.insert(0, {
+            "status": status,
+            "effective_date": datetime.now().replace(hour=0, minute=0, second=0, microsecond=0),
+            "changed_by": str(changed_by) if changed_by else None,
+            "changed_by_name": changed_by_name,
+            "created_at": datetime.now(),
+        })
+
+    db.userProfiles.update_one(
+        {"django_user_id": str(django_user_id)},
+        {"$set": {
+            "status": status,
+            "status_history": history,
+            "updated_at": datetime.now(),
+        }},
+    )
+    return changed, prev_status

--- a/accounts/middleware.py
+++ b/accounts/middleware.py
@@ -2,6 +2,7 @@ from django.shortcuts import redirect
 from django.urls import reverse, resolve
 from django.conf import settings
 from django.apps import apps
+from django.contrib.auth import logout
 
 class PermissionMiddleware:
     def __init__(self, get_response):
@@ -21,6 +22,11 @@ class PermissionMiddleware:
 
         # Check if user is authenticated
         if not request.user.is_authenticated:
+            return redirect(f"{reverse('login')}?next={request.path}")
+
+        # Deactivated mid-session (put on hold / made inactive): end the session now.
+        if not request.user.is_active:
+            logout(request)
             return redirect(f"{reverse('login')}?next={request.path}")
 
         # Allow superusers full access

--- a/accounts/templates/accounts/create_user.html
+++ b/accounts/templates/accounts/create_user.html
@@ -136,6 +136,13 @@
                             <input type="checkbox" class="form-check-input" id="is_active" name="is_active" checked>
                             <label class="form-check-label" for="is_active">Active Status</label>
                         </div>
+                        <div class="form-check mb-1">
+                            <input type="checkbox" class="form-check-input" id="timesheet_mandatory" name="timesheet_mandatory" checked>
+                            <label class="form-check-label" for="timesheet_mandatory">Timesheet Mandatory</label>
+                        </div>
+                        <small class="form-text text-muted mb-3">
+                            Uncheck for users who are not required to fill timesheets; their days will be treated as optional until it is enabled.
+                        </small>
                     </div>
                 </div>
 

--- a/accounts/templates/accounts/create_user.html
+++ b/accounts/templates/accounts/create_user.html
@@ -131,12 +131,18 @@
                 </div>
 
                 <div class="row mt-3">
-                    <div class="col-md-12">
-                        <div class="form-check mb-3">
-                            <input type="checkbox" class="form-check-input" id="is_active" name="is_active" checked>
-                            <label class="form-check-label" for="is_active">Active Status</label>
+                    <div class="col-md-4">
+                        <div class="form-group">
+                            <label for="status">Account Status:</label>
+                            <select name="status" id="status" class="form-control">
+                                <option value="active" selected>Active</option>
+                                <option value="hold">On Hold</option>
+                                <option value="inactive">Inactive</option>
+                            </select>
                         </div>
-                        <div class="form-check mb-1">
+                    </div>
+                    <div class="col-md-8">
+                        <div class="form-check mb-1 mt-2">
                             <input type="checkbox" class="form-check-input" id="timesheet_mandatory" name="timesheet_mandatory" checked>
                             <label class="form-check-label" for="timesheet_mandatory">Timesheet Mandatory</label>
                         </div>

--- a/accounts/templates/accounts/edit_user.html
+++ b/accounts/templates/accounts/edit_user.html
@@ -191,6 +191,19 @@
                 </div>
                 {% endif %}
 
+                <div class="row mt-3">
+                    <div class="col-md-12">
+                        <div class="form-check mb-1">
+                            <input type="checkbox" class="form-check-input" id="timesheet_mandatory" name="timesheet_mandatory"
+                                   {% if user_profile.timesheet_mandatory %}checked{% endif %}>
+                            <label class="form-check-label" for="timesheet_mandatory">Timesheet Mandatory</label>
+                        </div>
+                        <small class="form-text text-muted mb-3">
+                            Unchecking marks all of this user's timesheets (past and going forward) as optional until it is re-enabled.
+                        </small>
+                    </div>
+                </div>
+
                 {% if user_profile.mandatory_history %}
                 <div class="row mt-3">
                     <div class="col-md-12">
@@ -232,22 +245,62 @@
                 {% endif %}
 
                 <div class="row mt-3">
-                    <div class="col-md-12">
-                        <div class="form-check mb-3">
-                            <input type="checkbox" class="form-check-input" id="is_active" name="is_active"
-                                   {% if edit_user.is_active %}checked{% endif %}>
-                            <label class="form-check-label" for="is_active">Active Status</label>
-                        </div>
-                        <div class="form-check mb-1">
-                            <input type="checkbox" class="form-check-input" id="timesheet_mandatory" name="timesheet_mandatory"
-                                   {% if user_profile.timesheet_mandatory %}checked{% endif %}>
-                            <label class="form-check-label" for="timesheet_mandatory">Timesheet Mandatory</label>
+                    <div class="col-md-4">
+                        <div class="form-group">
+                            <label for="status">Account Status:</label>
+                            <select name="status" id="status" class="form-control">
+                                <option value="active" {% if user_profile.status == 'active' %}selected{% endif %}>Active</option>
+                                <option value="hold" {% if user_profile.status == 'hold' %}selected{% endif %}>On Hold</option>
+                                <option value="inactive" {% if user_profile.status == 'inactive' %}selected{% endif %}>Inactive</option>
+                            </select>
                         </div>
                         <small class="form-text text-muted mb-3">
-                            Unchecking marks all of this user's timesheets (past and going forward) as optional until it is re-enabled.
+                            On Hold and Inactive both block login. On Hold exempts the user from timesheets for the time they are on hold; Inactive keeps all their data and can be reactivated.
                         </small>
                     </div>
                 </div>
+
+                {% if user_profile.status_history %}
+                <div class="row mt-3">
+                    <div class="col-md-12">
+                        <h6>Account Status History <span class="badge badge-info">{{ user_profile.status_history|length }} records</span></h6>
+                        <div class="table-responsive">
+                            <table class="table table-bordered table-hover">
+                                <thead class="thead-light">
+                                    <tr>
+                                        <th>Effective Date</th>
+                                        <th>Status</th>
+                                        <th>Changed By</th>
+                                        <th>Current</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for entry in user_profile.status_history %}
+                                    <tr {% if forloop.first %}class="table-primary"{% endif %}>
+                                        <td>{{ entry.effective_date|date:"d-m-Y" }}</td>
+                                        <td>
+                                            {% if entry.status == 'active' %}
+                                                <span class="badge badge-success">Active</span>
+                                            {% elif entry.status == 'hold' %}
+                                                <span class="badge badge-warning">On Hold</span>
+                                            {% else %}
+                                                <span class="badge badge-danger">Inactive</span>
+                                            {% endif %}
+                                        </td>
+                                        <td>{{ entry.changed_by_name|default:"-" }}</td>
+                                        <td>
+                                            {% if forloop.first %}
+                                                <span class="badge badge-success">Current</span>
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                {% endif %}
 
                 <div class="row mt-3">
                     <div class="col-md-12">

--- a/accounts/templates/accounts/edit_user.html
+++ b/accounts/templates/accounts/edit_user.html
@@ -191,13 +191,61 @@
                 </div>
                 {% endif %}
 
+                {% if user_profile.mandatory_history %}
+                <div class="row mt-3">
+                    <div class="col-md-12">
+                        <h6>Timesheet Mandatory History <span class="badge badge-info">{{ user_profile.mandatory_history|length }} records</span></h6>
+                        <div class="table-responsive">
+                            <table class="table table-bordered table-hover">
+                                <thead class="thead-light">
+                                    <tr>
+                                        <th>Effective Date</th>
+                                        <th>Timesheet Mandatory</th>
+                                        <th>Changed By</th>
+                                        <th>Status</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for entry in user_profile.mandatory_history %}
+                                    <tr {% if forloop.first %}class="table-primary"{% endif %}>
+                                        <td>{{ entry.effective_date|date:"d-m-Y" }}</td>
+                                        <td>
+                                            {% if entry.mandatory %}
+                                                <span class="badge badge-success">Yes</span>
+                                            {% else %}
+                                                <span class="badge badge-secondary">No</span>
+                                            {% endif %}
+                                        </td>
+                                        <td>{{ entry.changed_by_name|default:"-" }}</td>
+                                        <td>
+                                            {% if forloop.first %}
+                                                <span class="badge badge-success">Current</span>
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                {% endif %}
+
                 <div class="row mt-3">
                     <div class="col-md-12">
                         <div class="form-check mb-3">
-                            <input type="checkbox" class="form-check-input" id="is_active" name="is_active" 
+                            <input type="checkbox" class="form-check-input" id="is_active" name="is_active"
                                    {% if edit_user.is_active %}checked{% endif %}>
                             <label class="form-check-label" for="is_active">Active Status</label>
                         </div>
+                        <div class="form-check mb-1">
+                            <input type="checkbox" class="form-check-input" id="timesheet_mandatory" name="timesheet_mandatory"
+                                   {% if user_profile.timesheet_mandatory %}checked{% endif %}>
+                            <label class="form-check-label" for="timesheet_mandatory">Timesheet Mandatory</label>
+                        </div>
+                        <small class="form-text text-muted mb-3">
+                            Unchecking marks all of this user's timesheets (past and going forward) as optional until it is re-enabled.
+                        </small>
                     </div>
                 </div>
 

--- a/accounts/templates/accounts/user_management.html
+++ b/accounts/templates/accounts/user_management.html
@@ -19,7 +19,7 @@
             <a href="{% url 'create_user' %}" class="btn btn-primary">Create New User</a>
         </div>
     </div>
-    
+
     <div class="table-responsive">
         <table cellpadding="1" cellspacing="2" border="0" class="table table-striped table-bordered dataTable" id="usersTable" width="100%">
             <thead>
@@ -36,8 +36,8 @@
             </thead>
             <tbody>
                 {% for user in users %}
-                {% if user.is_active %}
                 {% with profile=user.mongo_profile %}
+                {% if profile.status != 'inactive' %}
                 <tr>
                     <td>{{ forloop.counter }}</td>
                     <td>{{ user.username }}</td>
@@ -52,21 +52,18 @@
                     <td>{{ profile.area|default:"-" }}</td>
                     <td>{{ profile.designation|default:"-" }}</td>
                     <td>
-                        {% if user.is_active %}
-                        <span class="badge badge-success">Active</span>
+                        {% if profile.status == 'hold' %}
+                        <span class="badge badge-warning">On Hold</span>
                         {% else %}
-                        <span class="badge badge-danger">Inactive</span>
+                        <span class="badge badge-success">Active</span>
                         {% endif %}
                     </td>
                     <td>
                         <a href="{% url 'edit_user' user.id %}" class="btn btn-sm btn-info">Edit</a>
-                        {% if not user.is_superuser %}
-                        <button class="btn btn-sm btn-danger delete-user" data-userid="{{ user.id }}" data-username="{{ user.username }}">Delete</button>
-                        {% endif %}
                     </td>
                 </tr>
-                {% endwith %}
                 {% endif %}
+                {% endwith %}
                 {% endfor %}
             </tbody>
             <tfoot>
@@ -89,7 +86,7 @@
             <h4>Inactive Users</h4>
         </div>
     </div>
-    
+
     <div class="table-responsive">
         <table cellpadding="1" cellspacing="2" border="0" class="table table-striped table-bordered dataTable" id="inactiveUsersTable" width="100%">
             <thead>
@@ -106,8 +103,8 @@
             </thead>
             <tbody>
                 {% for user in users %}
-                {% if not user.is_active %}
                 {% with profile=user.mongo_profile %}
+                {% if profile.status == 'inactive' %}
                 <tr>
                     <td>{{ forloop.counter }}</td>
                     <td>{{ user.username }}</td>
@@ -122,21 +119,14 @@
                     <td>{{ profile.area|default:"-" }}</td>
                     <td>{{ profile.designation|default:"-" }}</td>
                     <td>
-                        {% if user.is_active %}
-                        <span class="badge badge-success">Active</span>
-                        {% else %}
                         <span class="badge badge-danger">Inactive</span>
-                        {% endif %}
                     </td>
                     <td>
                         <a href="{% url 'edit_user' user.id %}" class="btn btn-sm btn-info">Edit</a>
-                        {% if not user.is_superuser %}
-                        <button class="btn btn-sm btn-danger delete-user" data-userid="{{ user.id }}" data-username="{{ user.username }}">Delete</button>
-                        {% endif %}
                     </td>
                 </tr>
-                {% endwith %}
                 {% endif %}
+                {% endwith %}
                 {% endfor %}
             </tbody>
             <tfoot>
@@ -155,88 +145,7 @@
     </div>
 </div>
 
-<!-- Delete User Modal -->
-<div class="modal fade" id="deleteUserModal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Confirm Delete</h5>
-                <button type="button" class="close" data-dismiss="modal">
-                    <span>&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-                <p>Are you sure you want to delete user <span id="deleteUsername"></span>?</p>
-                <form id="deleteUserForm">
-                    {% csrf_token %}
-                    <div class="form-group">
-                        <label>Enter your password to confirm:</label>
-                        <input type="password" class="form-control" id="confirmPassword" required>
-                    </div>
-                </form>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-                <button type="button" class="btn btn-danger" id="confirmDelete">Delete</button>
-            </div>
-        </div>
-    </div>
-</div>
-
 <script>
-    document.addEventListener('DOMContentLoaded', function() {
-        let userToDelete = null;
-
-        // Handle delete button click
-        document.querySelectorAll('.delete-user').forEach(button => {
-            button.addEventListener('click', function() {
-                userToDelete = this.dataset.userid;
-                document.getElementById('deleteUsername').textContent = this.dataset.username;
-                $('#deleteUserModal').modal('show');
-            });
-        });
-
-        // Handle delete confirmation
-        document.getElementById('confirmDelete').addEventListener('click', function() {
-            const password = document.getElementById('confirmPassword').value;
-            if (!password) {
-                alert('Please enter your password');
-                return;
-            }
-
-            const formData = new FormData();
-            formData.append('password', password);
-            formData.append('csrfmiddlewaretoken', document.querySelector('[name=csrfmiddlewaretoken]').value);
-
-            fetch(`/accounts/users/${userToDelete}/delete/`, {
-                method: 'POST',
-                headers: {
-                    'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
-                },
-                body: formData
-            })
-            .then(response => {
-                if (!response.ok) {
-                    return response.json().then(data => {
-                        throw new Error(data.message || 'Error deleting user');
-                    });
-                }
-                return response.json();
-            })
-            .then(data => {
-                if (data.status === 'success') {
-                    $('#deleteUserModal').modal('hide');
-                    location.reload();
-                } else {
-                    alert(data.message || 'Error deleting user');
-                }
-            })
-            .catch(error => {
-                alert(error.message || 'An error occurred while deleting the user');
-            });
-        });
-    });
-
     $(document).ready(function() {
         var commonSettings = {
             dom: 'Bfrtip',
@@ -265,4 +174,4 @@
         }));
     });
 </script>
-{% endblock %} 
+{% endblock %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -8,6 +8,5 @@ urlpatterns = [
     path('users/', views.user_management, name='user_management'),
     path('users/create/', views.create_user, name='create_user'),
     path('users/<int:user_id>/edit/', views.edit_user, name='edit_user'),
-    path('users/<int:user_id>/delete/', views.delete_user, name='delete_user'),
     path('permission-denied/', views.permission_denied, name='permission_denied'),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -5,7 +5,7 @@ from django.http import JsonResponse
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.contrib import messages
 from django.urls import reverse
-from accounts.database import delete_user_profile_mongo,get_all_groups, create_user_profile_mongo, get_user_profile_mongo, update_user_profile_mongo, create_group_head_assignments, update_group_head_assignments, remove_group_head_assignments, set_timesheet_mandatory, is_timesheet_mandatory
+from accounts.database import delete_user_profile_mongo,get_all_groups, create_user_profile_mongo, get_user_profile_mongo, update_user_profile_mongo, create_group_head_assignments, update_group_head_assignments, remove_group_head_assignments, set_timesheet_mandatory, is_timesheet_mandatory, set_user_status, get_user_status
 from datetime import datetime
 from django.conf import settings
 from accounts.roles import ROLE_PERMISSIONS
@@ -13,6 +13,26 @@ from accounts.decorators import permission_required
 
 def is_superuser(user):
     return user.is_superuser
+
+
+def _apply_status_change(request, user_id, new_status, prev_status, prev_status_effective, user_start):
+    """Record an account-status change; on return to Active, excuse the away period.
+
+    When a user comes back from Hold/Inactive, the days they were away are marked
+    optional (reusing the timesheet optional-day mechanism) so they never show as
+    pending/critical. Returns True if the status actually changed.
+    """
+    changed, _ = set_user_status(user_id, new_status, request.user.id, request.user.get_full_name())
+    if changed and new_status == 'active' and prev_status in ('hold', 'inactive'):
+        from timesheet.database import mark_period_optional
+        today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        start = prev_status_effective or user_start or settings.TIMESHEET_START_DATE
+        reason = 'ON HOLD' if prev_status == 'hold' else 'INACTIVE PERIOD'
+        mark_period_optional(
+            user_id, start, today, reason=reason,
+            marked_by=request.user.id, marked_by_name=request.user.get_full_name(),
+        )
+    return changed
 
 @ensure_csrf_cookie
 def login_view(request):
@@ -42,10 +62,13 @@ def user_management(request):
     # Get all users except the current user
     users = User.objects.all().exclude(id=request.user.id)
     
-    # Attach MongoDB profiles to users
+    # Attach MongoDB profiles to users, with an effective status for legacy profiles.
     for user in users:
-        user.mongo_profile = get_user_profile_mongo(user.id)
-    
+        profile = get_user_profile_mongo(user.id)
+        if profile is not None:
+            profile['status'] = profile.get('status') or ('active' if user.is_active else 'inactive')
+        user.mongo_profile = profile
+
     return render(request, 'accounts/user_management.html', {'users': users})
 
 
@@ -58,7 +81,8 @@ def create_user(request):
         first_name = request.POST.get('first_name').upper()
         last_name = request.POST.get('last_name').upper()
         role = request.POST.get('role')
-        is_active = request.POST.get('is_active', 'on') == 'on'
+        status = request.POST.get('status', 'active')
+        is_active = status == 'active'
 
         try:
             # Create Django user
@@ -100,6 +124,7 @@ def create_user(request):
                 'designation': request.POST.get('designation', '').upper(),
                 'role': role,
                 'timesheet_mandatory': timesheet_mandatory,
+                'status': status,
                 'changed_by': request.user.id,
                 'changed_by_name': request.user.get_full_name(),
                 'time_in': request.POST.get('time_in'),
@@ -147,8 +172,16 @@ def edit_user(request, user_id):
             editing_user.email = request.POST.get('email')
             editing_user.first_name = request.POST.get('first_name').upper()
             editing_user.last_name = request.POST.get('last_name').upper()
-            editing_user.is_active = request.POST.get('is_active') == 'on'
-            
+            # Account status drives Django's is_active (active -> can log in).
+            new_status = request.POST.get('status', 'active')
+            if new_status not in ('active', 'hold', 'inactive'):
+                new_status = 'active'
+            prev_status = get_user_status(mongo_profile)
+            prev_status_effective = None
+            if mongo_profile and mongo_profile.get('status_history'):
+                prev_status_effective = mongo_profile['status_history'][0].get('effective_date')
+            editing_user.is_active = new_status == 'active'
+
             # Handle password change if provided
             if request.POST.get('password'):
                 editing_user.set_password(request.POST.get('password'))
@@ -240,6 +273,12 @@ def edit_user(request, user_id):
                     marked_by=request.user.id, marked_by_name=request.user.get_full_name(),
                 )
 
+            # Account status toggle + audit history.
+            _apply_status_change(
+                request, user_id, new_status, prev_status, prev_status_effective,
+                effective_date or (mongo_profile.get('effective_date') if mongo_profile else None),
+            )
+
             messages.success(request, f'User {editing_user.username} has been updated successfully.')
             return redirect('user_management')
             
@@ -270,6 +309,8 @@ def edit_user(request, user_id):
             'hourly_rate': mongo_profile.get('hourly_rate'),
             'timesheet_mandatory': is_timesheet_mandatory(mongo_profile),
             'mandatory_history': mongo_profile.get('mandatory_history', []),  # already newest-first
+            'status': get_user_status(mongo_profile) if mongo_profile.get('status') else ('active' if editing_user.is_active else 'inactive'),
+            'status_history': mongo_profile.get('status_history', []),  # already newest-first
             'rate_history': sorted(
                 mongo_profile.get('rate_history', []),
                 key=lambda x: x['effective_date'],
@@ -278,6 +319,7 @@ def edit_user(request, user_id):
         })
     else:
         user_data['timesheet_mandatory'] = True
+        user_data['status'] = 'active' if editing_user.is_active else 'inactive'
     
     context = {
         'edit_user': editing_user,
@@ -288,55 +330,6 @@ def edit_user(request, user_id):
     }
     
     return render(request, 'accounts/edit_user.html', context)
-
-@permission_required('accounts', 'delete')
-def delete_user(request, user_id):
-    if request.method != 'POST':
-        return JsonResponse({
-            'status': 'error',
-            'message': 'Invalid request method'
-        }, status=405)
-
-    try:
-        # Get the user to delete
-        user_to_delete = User.objects.get(id=user_id)
-        # Prevent superuser from being deleted
-        if user_to_delete.is_superuser:
-            return JsonResponse({
-                'status': 'error',
-                'message': 'Cannot delete superuser account'
-            }, status=403)
-
-        # Verify the current user's password
-        password = request.POST.get('password')
-        if not request.user.check_password(password):
-            return JsonResponse({
-                'status': 'error',
-                'message': 'Invalid password'
-            }, status=403)
-
-        # Delete the user
-        user_to_delete.delete()
-
-        #delete the user from the mongo db
-        delete_user_profile_mongo(user_id)
-
-        messages.success(request, 'User deleted successfully.')
-        return JsonResponse({
-            'status': 'success',
-            'message': 'User deleted successfully'
-        })
-
-    except User.DoesNotExist:
-        return JsonResponse({
-            'status': 'error',
-            'message': 'User not found'
-        }, status=404)
-    except Exception as e:
-        return JsonResponse({
-            'status': 'error',
-            'message': str(e)
-        }, status=500)
 
 def permission_denied(request):
     # Get the user's current roles/groups

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -5,8 +5,9 @@ from django.http import JsonResponse
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.contrib import messages
 from django.urls import reverse
-from accounts.database import delete_user_profile_mongo,get_all_groups, create_user_profile_mongo, get_user_profile_mongo, update_user_profile_mongo, create_group_head_assignments, update_group_head_assignments, remove_group_head_assignments
+from accounts.database import delete_user_profile_mongo,get_all_groups, create_user_profile_mongo, get_user_profile_mongo, update_user_profile_mongo, create_group_head_assignments, update_group_head_assignments, remove_group_head_assignments, set_timesheet_mandatory, is_timesheet_mandatory
 from datetime import datetime
+from django.conf import settings
 from accounts.roles import ROLE_PERMISSIONS
 from accounts.decorators import permission_required
 
@@ -90,13 +91,17 @@ def create_user(request):
             # Create MongoDB profile with rate history
             effective_date = datetime.strptime(request.POST.get('effective_date'), '%Y-%m-%d')
             hourly_rate = request.POST.get('hourly_rate')
-            
+            timesheet_mandatory = request.POST.get('timesheet_mandatory') == 'on'
+
             profile_data = {
                 'user': user,
                 'area': request.POST.get('area', '').upper(),
                 'groups': groups,
                 'designation': request.POST.get('designation', '').upper(),
                 'role': role,
+                'timesheet_mandatory': timesheet_mandatory,
+                'changed_by': request.user.id,
+                'changed_by_name': request.user.get_full_name(),
                 'time_in': request.POST.get('time_in'),
                 'time_out': request.POST.get('time_out'),
                 'effective_date': effective_date,
@@ -107,6 +112,16 @@ def create_user(request):
                 }] if hourly_rate else []
             }
             create_user_profile_mongo(profile_data)
+
+            # New user starting as non-mandatory: mark their timesheets optional from day one.
+            if not timesheet_mandatory:
+                from timesheet.database import mark_period_optional
+                today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+                mark_period_optional(
+                    user.id, effective_date, today,
+                    reason='TIMESHEET NOT MANDATORY',
+                    marked_by=request.user.id, marked_by_name=request.user.get_full_name(),
+                )
 
             messages.success(request, f'User {username} has been created successfully.')
             return JsonResponse({'status': 'success', 'redirect_url': reverse('user_management')})
@@ -208,6 +223,23 @@ def edit_user(request, user_id):
             # Update MongoDB profile
             update_user_profile_mongo(user_id, profile_data)
 
+            # Timesheet-mandatory toggle + audit history (kept separate so update_user_profile_mongo
+            # doesn't clobber the mandatory fields).
+            timesheet_mandatory = request.POST.get('timesheet_mandatory') == 'on'
+            changed = set_timesheet_mandatory(
+                user_id, timesheet_mandatory, request.user.id, request.user.get_full_name()
+            )
+            # Switched off: retroactively mark every working day from the user's start optional.
+            if changed and not timesheet_mandatory:
+                from timesheet.database import mark_period_optional
+                start = effective_date or (mongo_profile.get('effective_date') if mongo_profile else None) or settings.TIMESHEET_START_DATE
+                today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+                mark_period_optional(
+                    user_id, start, today,
+                    reason='TIMESHEET NOT MANDATORY',
+                    marked_by=request.user.id, marked_by_name=request.user.get_full_name(),
+                )
+
             messages.success(request, f'User {editing_user.username} has been updated successfully.')
             return redirect('user_management')
             
@@ -236,12 +268,16 @@ def edit_user(request, user_id):
             'time_out': mongo_profile.get('time_out', ''),
             'effective_date': mongo_profile.get('effective_date'),
             'hourly_rate': mongo_profile.get('hourly_rate'),
+            'timesheet_mandatory': is_timesheet_mandatory(mongo_profile),
+            'mandatory_history': mongo_profile.get('mandatory_history', []),  # already newest-first
             'rate_history': sorted(
                 mongo_profile.get('rate_history', []),
                 key=lambda x: x['effective_date'],
                 reverse=True
             )
         })
+    else:
+        user_data['timesheet_mandatory'] = True
     
     context = {
         'edit_user': editing_user,

--- a/timesheet/database.py
+++ b/timesheet/database.py
@@ -1,5 +1,6 @@
 import pymongo
-from datetime import datetime
+from pymongo.errors import BulkWriteError, PyMongoError
+from datetime import datetime, timedelta
 from bson.objectid import ObjectId
 from accounts.views import get_user_name
 
@@ -207,6 +208,27 @@ def mark_optional_days(user_id, dates, reason='', marked_by=None, marked_by_name
     return count
 
 
+def mark_period_optional(user_id, start, end, reason='', marked_by=None, marked_by_name=None):
+    """Mark every working day (Mon-Sat) in [start, end] optional via optionalDayMaster.
+
+    One-time retroactive cleanup used when an admin flips a user to non-mandatory, so their
+    accumulated past pending days stop counting. Reuses the idempotent mark_optional_days upsert.
+    Returns the number of days processed.
+    """
+    cur = _normalize_date(start)
+    end = _normalize_date(end)
+    dates = []
+    while cur <= end:
+        if cur.weekday() != 6:  # skip Sundays
+            dates.append(cur)
+        cur += timedelta(days=1)
+    if not dates:
+        return 0
+    return mark_optional_days(
+        user_id, dates, reason=reason, marked_by=marked_by, marked_by_name=marked_by_name
+    )
+
+
 def unmark_optional_days(user_id, dates):
     """Remove optional-day marks for the given dates. Returns the number deleted."""
     norm = [_normalize_date(d) for d in dates]
@@ -241,6 +263,175 @@ def get_optional_days_detail(user_id, start, end):
         {'_id': 0},
     ).sort('date', 1)
     return list(docs)
+
+
+# ---------------------------------------------------------------------------
+# Random weekly timesheet verification (timesheetVerificationMaster)
+# One document per (verifier, employee, week_start); week_start is the Monday
+# of the reviewed Mon-Sat week, normalized to midnight like timesheetMaster.date.
+# ---------------------------------------------------------------------------
+
+try:
+    # Unique index makes lazy allocation race-safe: if two requests generate the
+    # same week concurrently, the loser's duplicates are skipped (see
+    # create_allocations). Wrapped so the app still imports when Mongo is down.
+    db.timesheetVerificationMaster.create_index(
+        [('verifier_id', 1), ('employee_id', 1), ('week_start', 1)],
+        unique=True,
+    )
+except PyMongoError:
+    pass
+
+
+def has_allocations(verifier_id, week_start):
+    """Check whether the verifier already has allocations for the given week."""
+    return db.timesheetVerificationMaster.count_documents(
+        {'verifier_id': str(verifier_id), 'week_start': _normalize_date(week_start)},
+        limit=1,
+    ) > 0
+
+
+def get_last_allocation_map(verifier_id, employee_ids):
+    """Return {employee_id: most recent week_start} this verifier was allocated them.
+
+    Used to prefer least-recently-reviewed employees when sampling a new week.
+    """
+    pipeline = [
+        {'$match': {
+            'verifier_id': str(verifier_id),
+            'employee_id': {'$in': [str(e) for e in employee_ids]},
+        }},
+        {'$group': {'_id': '$employee_id', 'last_week': {'$max': '$week_start'}}},
+    ]
+    return {doc['_id']: doc['last_week']
+            for doc in db.timesheetVerificationMaster.aggregate(pipeline)}
+
+
+def create_allocations(docs):
+    """Insert pending allocation docs; duplicates on (verifier, employee, week) are skipped."""
+    if not docs:
+        return 0
+    now = datetime.now()
+    for doc in docs:
+        doc.setdefault('status', 'pending')
+        doc.setdefault('remarks', '')
+        doc.setdefault('verified_at', None)
+        doc.setdefault('allocated_at', now)
+    try:
+        result = db.timesheetVerificationMaster.insert_many(docs, ordered=False)
+        return len(result.inserted_ids)
+    except BulkWriteError:
+        # Concurrent generation (e.g. two tabs) raced us; the unique index
+        # already holds the winner's docs, so there is nothing left to do.
+        return 0
+
+
+def get_my_allocations(verifier_id):
+    """Return all allocation docs for a verifier: pending first, newest week first.
+
+    _id is exposed as a plain 'id' string because Django templates reject
+    leading-underscore attributes.
+    """
+    docs = list(db.timesheetVerificationMaster.find({'verifier_id': str(verifier_id)}))
+    for doc in docs:
+        doc['id'] = str(doc.pop('_id'))
+    docs.sort(key=lambda d: (d.get('status') != 'pending', -d['week_start'].timestamp()))
+    return docs
+
+
+def count_pending_verifications(verifier_id):
+    """Number of allocations still awaiting this verifier's review."""
+    return db.timesheetVerificationMaster.count_documents(
+        {'verifier_id': str(verifier_id), 'status': 'pending'}
+    )
+
+
+def get_allocation(allocation_id):
+    """Fetch one allocation doc by its string _id, or None if missing/invalid."""
+    try:
+        doc = db.timesheetVerificationMaster.find_one({'_id': ObjectId(allocation_id)})
+    except Exception:
+        return None
+    if doc:
+        doc['id'] = str(doc.pop('_id'))
+    return doc
+
+
+def decide_allocation(allocation_id, verifier_id, status, remarks='', bypass_verifier=False):
+    """Record a verified/flagged decision on a still-pending allocation.
+
+    Only flips docs whose status is 'pending'; returns False when the doc was
+    already decided (stale tab) or belongs to another verifier (unless bypassed).
+    """
+    try:
+        query = {'_id': ObjectId(allocation_id), 'status': 'pending'}
+    except Exception:
+        return False
+    if not bypass_verifier:
+        query['verifier_id'] = str(verifier_id)
+    result = db.timesheetVerificationMaster.update_one(
+        query,
+        {'$set': {
+            'status': status,
+            'remarks': (remarks or '').upper(),
+            'verified_at': datetime.now(),
+        }},
+    )
+    return result.modified_count > 0
+
+
+def get_verification_log(scope_query=None, week_start=None, status=None, group=None, employee_id=None):
+    """Allocations for the log tab, newest week first.
+
+    scope_query restricts visibility (e.g. a Group Head's own groups); status
+    'decided' means verified+flagged, 'all' disables the status filter.
+    """
+    clauses = []
+    if scope_query:
+        clauses.append(scope_query)
+    if week_start:
+        clauses.append({'week_start': _normalize_date(week_start)})
+    if status == 'decided':
+        clauses.append({'status': {'$in': ['verified', 'flagged']}})
+    elif status and status != 'all':
+        clauses.append({'status': status})
+    if group:
+        clauses.append({'groups': group})
+    if employee_id:
+        clauses.append({'employee_id': str(employee_id)})
+    query = {'$and': clauses} if clauses else {}
+    docs = list(db.timesheetVerificationMaster.find(query)
+                .sort([('week_start', -1), ('verified_at', -1)]))
+    for doc in docs:
+        doc['id'] = str(doc.pop('_id'))
+    return docs
+
+
+def get_verification_employees(scope_query=None):
+    """Distinct employees appearing in verification docs (for the log filter dropdown)."""
+    pipeline = []
+    if scope_query:
+        pipeline.append({'$match': scope_query})
+    pipeline += [
+        {'$group': {'_id': '$employee_id', 'name': {'$first': '$employee_name'}}},
+        {'$sort': {'name': 1}},
+    ]
+    return [{'id': doc['_id'], 'name': doc['name']}
+            for doc in db.timesheetVerificationMaster.aggregate(pipeline)]
+
+
+def get_week_entries(user_id, week_start):
+    """Timesheet entries for Mon-Sat of the given week, grouped by 'YYYY-MM-DD'."""
+    start = _normalize_date(week_start)
+    end = start + timedelta(days=5)
+    entries = list(db.timesheetMaster.find(
+        {'user_id': str(user_id), 'date': {'$gte': start, '$lte': end}},
+        {'_id': 0},
+    ).sort('created_at', -1))
+    grouped = {}
+    for entry in entries:
+        grouped.setdefault(entry['date'].strftime('%Y-%m-%d'), []).append(entry)
+    return grouped
 
 
 def get_user_timesheets_by_task_assignment(assignment_id):

--- a/timesheet/database.py
+++ b/timesheet/database.py
@@ -176,6 +176,73 @@ def is_leave(user_id, date):
     return bool(db.leaveMaster.find_one({'user_id': str(user_id), 'date': date}))
 
 
+def _normalize_date(d):
+    """Normalize a datetime to midnight, matching timesheetMaster.date / effective_date storage."""
+    return d.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def mark_optional_days(user_id, dates, reason='', marked_by=None, marked_by_name=None):
+    """Mark each date in `dates` as an optional (non-pending) timesheet day for a user.
+
+    One document per (user_id, date); idempotent upsert so re-marking updates the reason
+    instead of duplicating. Sundays are NOT filtered here - the caller expands working days.
+    Returns the number of dates processed.
+    """
+    count = 0
+    for d in dates:
+        nd = _normalize_date(d)
+        db.optionalDayMaster.update_one(
+            {'user_id': str(user_id), 'date': nd},
+            {
+                '$set': {
+                    'reason': (reason or '').upper(),
+                    'marked_by': str(marked_by) if marked_by else None,
+                    'marked_by_name': marked_by_name,
+                },
+                '$setOnInsert': {'created_at': datetime.now()},
+            },
+            upsert=True,
+        )
+        count += 1
+    return count
+
+
+def unmark_optional_days(user_id, dates):
+    """Remove optional-day marks for the given dates. Returns the number deleted."""
+    norm = [_normalize_date(d) for d in dates]
+    result = db.optionalDayMaster.delete_many(
+        {'user_id': str(user_id), 'date': {'$in': norm}}
+    )
+    return result.deleted_count
+
+
+def get_optional_dates(user_id, start, end):
+    """Return a set of normalized (midnight) datetimes marked optional in [start, end].
+
+    Used to prefetch a user's optional days for O(1) membership checks in the pending loops.
+    """
+    docs = db.optionalDayMaster.find(
+        {
+            'user_id': str(user_id),
+            'date': {'$gte': _normalize_date(start), '$lte': _normalize_date(end)},
+        },
+        {'_id': 0, 'date': 1},
+    )
+    return {doc['date'] for doc in docs}
+
+
+def get_optional_days_detail(user_id, start, end):
+    """Return [{date, reason, marked_by_name}] for a user's optional days in [start, end]."""
+    docs = db.optionalDayMaster.find(
+        {
+            'user_id': str(user_id),
+            'date': {'$gte': _normalize_date(start), '$lte': _normalize_date(end)},
+        },
+        {'_id': 0},
+    ).sort('date', 1)
+    return list(docs)
+
+
 def get_user_timesheets_by_task_assignment(assignment_id):
     """Get users who have worked on a specific task and assignment"""
     query = {'assignment_id': str(assignment_id)}

--- a/timesheet/templates/employee_corner.html
+++ b/timesheet/templates/employee_corner.html
@@ -3,7 +3,8 @@
 {% block body_block %}
 <div class="container">
     <h2 class="header">Employee Corner</h2>
-    
+    {% include 'includes/timesheet_manager_tabs.html' %}
+
     <!-- Date Selection Form -->
     <div class="card">
         <div class="card-body">

--- a/timesheet/templates/employee_corner.html
+++ b/timesheet/templates/employee_corner.html
@@ -50,10 +50,18 @@
                             {% endif %}
                         </td>
                         <td>
-                            <button onclick="toggleDetails('details-{{ data.user.id }}')" 
+                            <button onclick="toggleDetails('details-{{ data.user.id }}')"
                                     class="btn-primary">
                                 View Details
                             </button>
+                            {% if data.can_mark_optional %}
+                            <button class="btn-primary mark-optional-btn"
+                                    data-userid="{{ data.user.id }}"
+                                    data-username="{{ data.user.get_full_name }}"
+                                    data-optional="{{ data.optional_days|join:',' }}">
+                                Mark Optional
+                            </button>
+                            {% endif %}
                         </td>
                     </tr>
                     <tr>
@@ -95,6 +103,50 @@
                     {% endfor %}
                 </tbody>
             </table>
+        </div>
+    </div>
+</div>
+
+<!-- Mark Optional modal -->
+<div class="modal fade" id="optionalModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Mark Optional Days &mdash; <span id="optName"></span></h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" id="optUserId">
+                <p class="text-muted" style="font-size:0.85em;">Marked days stop counting as pending and won't block the employee's timesheet. Sundays are skipped automatically.</p>
+                <div class="form-group">
+                    <label style="margin-right:12px;"><input type="radio" name="optMode" value="day" checked> Single day</label>
+                    <label style="margin-right:12px;"><input type="radio" name="optMode" value="range"> Date range</label>
+                    <label><input type="radio" name="optMode" value="week"> Whole week</label>
+                </div>
+                <div class="form-group opt-field" id="optDayField">
+                    <label>Date</label>
+                    <input type="date" id="optDate" class="form-control">
+                </div>
+                <div class="form-group opt-field" id="optRangeField" style="display:none;">
+                    <label>From</label>
+                    <input type="date" id="optStart" class="form-control">
+                    <label style="margin-top:8px;">To</label>
+                    <input type="date" id="optEnd" class="form-control">
+                </div>
+                <div class="form-group opt-field" id="optWeekField" style="display:none;">
+                    <label>Any date in the week (Mon&ndash;Sat will be marked)</label>
+                    <input type="date" id="optWeek" class="form-control">
+                </div>
+                <div class="form-group">
+                    <label>Reason (optional)</label>
+                    <input type="text" id="optReason" class="form-control" placeholder="e.g. Approved leave, field work">
+                </div>
+                <div id="optExisting"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                <button type="button" class="btn-primary" id="optSubmit">Mark Optional</button>
+            </div>
         </div>
     </div>
 </div>
@@ -233,5 +285,82 @@
         const button = event.target;
         button.textContent = isHidden ? 'Hide Details' : 'View Details';
     }
+
+    // ----- Mark Optional days (Super Group Head / Super Admin only) -----
+    (function () {
+        const csrftoken = '{{ csrf_token }}';
+
+        function showField() {
+            const mode = document.querySelector('input[name=optMode]:checked').value;
+            document.getElementById('optDayField').style.display = mode === 'day' ? 'block' : 'none';
+            document.getElementById('optRangeField').style.display = mode === 'range' ? 'block' : 'none';
+            document.getElementById('optWeekField').style.display = mode === 'week' ? 'block' : 'none';
+        }
+        document.querySelectorAll('input[name=optMode]').forEach(function (r) {
+            r.addEventListener('change', showField);
+        });
+
+        function renderExisting(userId, optionalCsv) {
+            const wrap = document.getElementById('optExisting');
+            const days = optionalCsv ? optionalCsv.split(',').filter(Boolean) : [];
+            if (!days.length) {
+                wrap.innerHTML = '<hr><p class="no-entries">No optional days marked.</p>';
+                return;
+            }
+            let html = '<hr><strong>Current optional days</strong><ul style="padding-left:18px;margin-top:6px;">';
+            days.forEach(function (d) {
+                html += '<li style="margin-bottom:4px;">' + d +
+                    ' <button class="btn-primary opt-unmark" data-date="' + d + '" style="padding:1px 6px;font-size:0.8em;">Unmark</button></li>';
+            });
+            html += '</ul>';
+            wrap.innerHTML = html;
+            wrap.querySelectorAll('.opt-unmark').forEach(function (b) {
+                b.addEventListener('click', function () {
+                    unmarkOptional(userId, this.getAttribute('data-date'));
+                });
+            });
+        }
+
+        document.querySelectorAll('.mark-optional-btn').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                const userId = this.getAttribute('data-userid');
+                document.getElementById('optUserId').value = userId;
+                document.getElementById('optName').textContent = this.getAttribute('data-username');
+                document.getElementById('optReason').value = '';
+                renderExisting(userId, this.getAttribute('data-optional'));
+                $('#optionalModal').modal('show');
+            });
+        });
+
+        const submitBtn = document.getElementById('optSubmit');
+        if (submitBtn) {
+            submitBtn.addEventListener('click', function () {
+                const userId = document.getElementById('optUserId').value;
+                const mode = document.querySelector('input[name=optMode]:checked').value;
+                const data = {
+                    user_id: userId, mode: mode,
+                    reason: document.getElementById('optReason').value,
+                    csrfmiddlewaretoken: csrftoken
+                };
+                if (mode === 'day') {
+                    data.date = document.getElementById('optDate').value;
+                } else if (mode === 'range') {
+                    data.start_date = document.getElementById('optStart').value;
+                    data.end_date = document.getElementById('optEnd').value;
+                } else {
+                    data.week_start = document.getElementById('optWeek').value;
+                }
+                $.post('{% url "mark_optional_days" %}', data)
+                    .done(function (r) { if (r.status === 'success') { location.reload(); } else { alert(r.message || 'Error'); } })
+                    .fail(function (x) { alert((x.responseJSON && x.responseJSON.message) || 'Error marking optional days.'); });
+            });
+        }
+
+        function unmarkOptional(userId, date) {
+            $.post('{% url "unmark_optional_days" %}', { user_id: userId, date: date, csrfmiddlewaretoken: csrftoken })
+                .done(function (r) { if (r.status === 'success') { location.reload(); } else { alert(r.message || 'Error'); } })
+                .fail(function (x) { alert((x.responseJSON && x.responseJSON.message) || 'Error removing optional day.'); });
+        }
+    })();
 </script>
 {% endblock %}

--- a/timesheet/templates/fill_timesheet.html
+++ b/timesheet/templates/fill_timesheet.html
@@ -369,7 +369,12 @@
     {% if request.user.groups.all|length > 0 and 'Group Head' in request.user.groups.all|join:" " or 'Super Group Head' in request.user.groups.all|join:" " or 'Super Admin' in request.user.groups.all|join:" " %}
     <div class="row">
         <div class="col-md-12">
-            <button class="btn btn-primary" onclick="window.open('{% url 'employee_corner' %}', '_blank')">Employee Corner</button>
+            <button class="btn btn-primary" onclick="window.open('{% url 'employee_corner' %}', '_blank')">
+                Employee Corner
+                {% if pending_verification_count %}
+                <span class="badge badge-light" title="{{ pending_verification_count }} timesheet verification(s) pending">{{ pending_verification_count }} to verify</span>
+                {% endif %}
+            </button>
         </div>
     </div>
     {% endif %}

--- a/timesheet/templates/includes/timesheet_manager_tabs.html
+++ b/timesheet/templates/includes/timesheet_manager_tabs.html
@@ -1,0 +1,65 @@
+{% if show_manager_tabs %}
+<ul class="ts-manager-tabs">
+    <li class="{% if active_tab == 'overview' %}active{% endif %}">
+        <a href="{% url 'employee_corner' %}">Daily Overview</a>
+    </li>
+    <li class="{% if active_tab == 'verifications' %}active{% endif %}">
+        <a href="{% url 'my_verifications' %}">
+            My Verifications
+            {% if pending_verification_count %}
+            <span class="ts-tab-badge">{{ pending_verification_count }}</span>
+            {% endif %}
+        </a>
+    </li>
+    <li class="{% if active_tab == 'log' %}active{% endif %}">
+        <a href="{% url 'verification_log' %}">Verification Log</a>
+    </li>
+</ul>
+<style>
+    .ts-manager-tabs {
+        list-style: none;
+        display: flex;
+        padding: 0;
+        margin: 0 0 20px 0;
+        border-bottom: 2px solid #ddd;
+    }
+
+    .ts-manager-tabs li {
+        margin-right: 4px;
+    }
+
+    .ts-manager-tabs li a {
+        display: inline-block;
+        padding: 10px 18px;
+        color: #555;
+        text-decoration: none;
+        border: 1px solid transparent;
+        border-bottom: none;
+        border-radius: 4px 4px 0 0;
+        font-weight: 500;
+    }
+
+    .ts-manager-tabs li a:hover {
+        background: #f8f9fa;
+        text-decoration: none;
+    }
+
+    .ts-manager-tabs li.active a {
+        color: #0d6efd;
+        background: white;
+        border-color: #ddd;
+        border-bottom: 2px solid white;
+        margin-bottom: -2px;
+    }
+
+    .ts-tab-badge {
+        background: #dc3545;
+        color: white;
+        border-radius: 10px;
+        padding: 1px 8px;
+        font-size: 0.8em;
+        margin-left: 4px;
+        vertical-align: middle;
+    }
+</style>
+{% endif %}

--- a/timesheet/templates/my_verifications.html
+++ b/timesheet/templates/my_verifications.html
@@ -1,0 +1,214 @@
+{% extends 'layout.html' %}
+
+{% block body_block %}
+<div class="container">
+    <h2 class="header">Employee Corner</h2>
+    {% include 'includes/timesheet_manager_tabs.html' %}
+
+    {% if not is_verifier %}
+    <div class="card">
+        <div class="card-body">
+            <p class="no-entries">
+                Verification allocations are drawn for Group Heads and the Super Group Head.
+                Use the <a href="{% url 'verification_log' %}">Verification Log</a> to review all verified and flagged timesheets.
+            </p>
+        </div>
+    </div>
+    {% else %}
+
+    <div class="card">
+        <div class="card-header">
+            <h5>Pending Verifications</h5>
+        </div>
+        <div class="card-body">
+            {% if pending_allocations %}
+            <p class="hint-text">
+                A random sample of your team's timesheets is allocated to you each week for the
+                previous Mon&ndash;Sat week. Review each one and mark it Verified or Flag it for correction.
+            </p>
+            <table class="main-table">
+                <thead>
+                    <tr>
+                        <th>Week</th>
+                        <th>Employee</th>
+                        <th>Role</th>
+                        <th>Group(s)</th>
+                        <th>Allocated On</th>
+                        <th>Action</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for a in pending_allocations %}
+                    <tr>
+                        <td>{{ a.week_start|date:"d M" }} &ndash; {{ a.week_end|date:"d M Y" }}</td>
+                        <td>{{ a.employee_name }}</td>
+                        <td>{{ a.employee_role }}</td>
+                        <td>{{ a.groups|join:", "|default:"-" }}</td>
+                        <td>{{ a.allocated_at|date:"d M Y" }}</td>
+                        <td>
+                            <a href="{% url 'verification_detail' a.id %}" class="btn-primary btn-link-style">Review</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <p class="no-entries">
+                No pending verifications &mdash; a fresh random sample is allocated automatically
+                each week from your team's previous-week timesheets.
+            </p>
+            {% endif %}
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <h5>Recently Reviewed</h5>
+        </div>
+        <div class="card-body">
+            {% if reviewed_allocations %}
+            <table class="main-table">
+                <thead>
+                    <tr>
+                        <th>Week</th>
+                        <th>Employee</th>
+                        <th>Status</th>
+                        <th>Remarks</th>
+                        <th>Reviewed On</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for a in reviewed_allocations %}
+                    <tr>
+                        <td>{{ a.week_start|date:"d M" }} &ndash; {{ a.week_end|date:"d M Y" }}</td>
+                        <td>{{ a.employee_name }}</td>
+                        <td>
+                            {% if a.status == 'verified' %}
+                            <span class="badge success">Verified</span>
+                            {% else %}
+                            <span class="badge critical">Flagged</span>
+                            {% endif %}
+                        </td>
+                        <td class="remarks-cell">{{ a.remarks|default:"-" }}</td>
+                        <td>{{ a.verified_at|date:"d M Y" }}</td>
+                        <td>
+                            <a href="{% url 'verification_detail' a.id %}" class="btn-primary btn-link-style">View</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <p class="no-entries">Nothing reviewed yet.</p>
+            {% endif %}
+        </div>
+    </div>
+    {% endif %}
+</div>
+
+<style>
+    .container {
+        padding: 20px;
+        max-width: 1200px;
+        margin: 0 auto;
+    }
+
+    .header {
+        margin-bottom: 20px;
+    }
+
+    .card {
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        margin-bottom: 20px;
+        background: white;
+    }
+
+    .card-header {
+        padding: 10px 15px;
+        background: #f8f9fa;
+        border-bottom: 1px solid #ddd;
+    }
+
+    .card-body {
+        padding: 15px;
+    }
+
+    .main-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.9em;
+    }
+
+    .main-table th,
+    .main-table td {
+        padding: 8px 6px;
+        border: 1px solid #ddd;
+        text-align: left;
+        vertical-align: middle;
+    }
+
+    .main-table th {
+        background: #f8f9fa;
+        font-weight: 600;
+        white-space: nowrap;
+    }
+
+    .remarks-cell {
+        white-space: normal;
+        max-width: 320px;
+    }
+
+    .btn-primary {
+        background: #0d6efd;
+        color: white;
+        border: none;
+        padding: 5px 10px;
+        border-radius: 4px;
+        cursor: pointer;
+    }
+
+    .btn-primary:hover {
+        background: #0b5ed7;
+    }
+
+    .btn-link-style {
+        display: inline-block;
+        text-decoration: none;
+    }
+
+    .btn-link-style:hover {
+        color: white;
+        text-decoration: none;
+    }
+
+    .badge {
+        padding: 3px 8px;
+        border-radius: 3px;
+        font-size: 0.85em;
+    }
+
+    .badge.critical {
+        background: #dc3545;
+        color: white;
+    }
+
+    .badge.success {
+        background: #198754;
+        color: white;
+    }
+
+    .no-entries {
+        text-align: center;
+        color: #666;
+        margin: 10px 0;
+    }
+
+    .hint-text {
+        color: #666;
+        font-size: 0.9em;
+        margin-bottom: 12px;
+    }
+</style>
+{% endblock %}

--- a/timesheet/templates/verification_detail.html
+++ b/timesheet/templates/verification_detail.html
@@ -1,0 +1,311 @@
+{% extends 'layout.html' %}
+
+{% block body_block %}
+<div class="container">
+    <h2 class="header">Timesheet Verification</h2>
+    {% include 'includes/timesheet_manager_tabs.html' %}
+
+    <!-- Allocation summary -->
+    <div class="card">
+        <div class="card-header">
+            <h5>
+                {{ allocation.employee_name }} &mdash;
+                Week of {{ allocation.week_start|date:"d M" }} &ndash; {{ allocation.week_end|date:"d M Y" }}
+                {% if allocation.status == 'verified' %}
+                <span class="badge success">Verified</span>
+                {% elif allocation.status == 'flagged' %}
+                <span class="badge critical">Flagged</span>
+                {% else %}
+                <span class="badge warning">Pending Review</span>
+                {% endif %}
+            </h5>
+        </div>
+        <div class="card-body summary-grid">
+            <div><strong>Role:</strong> {{ allocation.employee_role|default:"-" }}</div>
+            <div><strong>Group(s):</strong> {{ allocation.groups|join:", "|default:"-" }}</div>
+            <div><strong>Verifier:</strong> {{ allocation.verifier_name }} ({{ allocation.verifier_role }})</div>
+            <div><strong>Allocated on:</strong> {{ allocation.allocated_at|date:"d M Y" }}</div>
+        </div>
+    </div>
+
+    <!-- Day-by-day entries -->
+    {% for row in day_rows %}
+    <div class="card day-card">
+        <div class="card-header day-header">
+            <span>
+                <strong>{{ row.date|date:"l" }}</strong>, {{ row.date|date:"d M Y" }}
+                {% if row.optional %}
+                <span class="badge optional" title="Marked by {{ row.optional.marked_by_name|default:'-' }}">
+                    Optional{% if row.optional.reason %}: {{ row.optional.reason }}{% endif %}
+                </span>
+                {% endif %}
+                {% if row.non_mandatory %}
+                <span class="badge optional">Timesheet not mandatory</span>
+                {% endif %}
+                {% if row.before_joining %}
+                <span class="badge muted">Before joining date</span>
+                {% endif %}
+            </span>
+            <span class="day-totals">
+                Total: <strong>{{ row.total_hours }}</strong> /
+                Expected: {{ row.standard_hours|floatformat:2 }} /
+                Pending:
+                <strong class="{% if row.pending_hours > 0 %}pending-red{% endif %}">{{ row.pending_hours }}</strong>
+            </span>
+        </div>
+        <div class="card-body">
+            {% if row.entries %}
+            <table class="details-table">
+                <thead>
+                    <tr>
+                        <th>Client</th>
+                        <th>Task</th>
+                        <th>Assignment</th>
+                        <th>Hours</th>
+                        <th>Time In</th>
+                        <th>Time Out</th>
+                        <th>Remarks</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for entry in row.entries %}
+                    <tr>
+                        <td>{{ entry.client_name }}</td>
+                        <td>{{ entry.task }}</td>
+                        <td>{{ entry.assignment }}</td>
+                        <td>{{ entry.hours }}</td>
+                        <td>{{ entry.time_in }}</td>
+                        <td>{{ entry.time_out }}</td>
+                        <td>{{ entry.remarks|default:"-" }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <p class="no-entries">No timesheet entries for this day</p>
+            {% endif %}
+        </div>
+    </div>
+    {% endfor %}
+
+    <!-- Week summary -->
+    <div class="card">
+        <div class="card-header"><h5>Week Summary</h5></div>
+        <div class="card-body summary-grid">
+            <div><strong>Total hours:</strong> {{ week_total }}</div>
+            <div>
+                <strong>Total pending:</strong>
+                <span class="{% if week_pending > 0 %}pending-red{% endif %}">{{ week_pending }}</span>
+            </div>
+            <div><strong>Days with entries:</strong> {{ days_with_entries }} / 6</div>
+        </div>
+    </div>
+
+    {% if can_decide %}
+    <!-- Decision -->
+    <div class="card">
+        <div class="card-header"><h5>Your Review</h5></div>
+        <div class="card-body">
+            <form method="post" action="{% url 'submit_verification' %}" id="decisionForm">
+                {% csrf_token %}
+                <input type="hidden" name="allocation_id" value="{{ allocation.id }}">
+                <div class="form-group">
+                    <label for="remarks">Remarks <span class="hint-text">(required when flagging)</span></label>
+                    <textarea name="remarks" id="remarks" class="form-control" rows="3"
+                              placeholder="e.g. Hours look consistent with assignments / Client codes missing on Tuesday"></textarea>
+                </div>
+                <button type="submit" name="action" value="verified" class="btn-verify"
+                        onclick="return confirmDecision(this)">Mark Verified</button>
+                <button type="submit" name="action" value="flagged" class="btn-flag"
+                        onclick="return confirmDecision(this)">Flag for Correction</button>
+            </form>
+        </div>
+    </div>
+    {% elif allocation.status != 'pending' %}
+    <!-- Read-only decision -->
+    <div class="card">
+        <div class="card-header"><h5>Review Outcome</h5></div>
+        <div class="card-body">
+            <p>
+                {% if allocation.status == 'verified' %}
+                <span class="badge success">Verified</span>
+                {% else %}
+                <span class="badge critical">Flagged for correction</span>
+                {% endif %}
+                by <strong>{{ allocation.verifier_name }}</strong>
+                on {{ allocation.verified_at|date:"d M Y, H:i" }}
+            </p>
+            <p><strong>Remarks:</strong> {{ allocation.remarks|default:"-" }}</p>
+        </div>
+    </div>
+    {% endif %}
+
+    <p>
+        <a href="{% url 'my_verifications' %}" class="back-link">&larr; Back to My Verifications</a>
+    </p>
+</div>
+
+<style>
+    .container {
+        padding: 20px;
+        max-width: 1200px;
+        margin: 0 auto;
+    }
+
+    .header {
+        margin-bottom: 20px;
+    }
+
+    .card {
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        margin-bottom: 20px;
+        background: white;
+    }
+
+    .card-header {
+        padding: 10px 15px;
+        background: #f8f9fa;
+        border-bottom: 1px solid #ddd;
+    }
+
+    .card-body {
+        padding: 15px;
+    }
+
+    .day-card {
+        margin-bottom: 12px;
+    }
+
+    .day-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+    }
+
+    .day-totals {
+        font-size: 0.9em;
+        color: #444;
+    }
+
+    .summary-grid {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 24px;
+        font-size: 0.95em;
+    }
+
+    .details-table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+
+    .details-table th,
+    .details-table td {
+        padding: 6px;
+        border: 1px solid #ddd;
+        font-size: 0.9em;
+        text-align: left;
+    }
+
+    .details-table th {
+        background: #f8f9fa;
+    }
+
+    .badge {
+        padding: 3px 8px;
+        border-radius: 3px;
+        font-size: 0.8em;
+        font-weight: normal;
+        vertical-align: middle;
+    }
+
+    .badge.critical {
+        background: #dc3545;
+        color: white;
+    }
+
+    .badge.warning {
+        background: #ffc107;
+        color: black;
+    }
+
+    .badge.success {
+        background: #198754;
+        color: white;
+    }
+
+    .badge.optional {
+        background: #6c757d;
+        color: white;
+    }
+
+    .badge.muted {
+        background: #e9ecef;
+        color: #555;
+    }
+
+    .pending-red {
+        color: #dc3545;
+        font-weight: 600;
+    }
+
+    .no-entries {
+        text-align: center;
+        color: #666;
+        margin: 10px 0;
+    }
+
+    .hint-text {
+        color: #888;
+        font-size: 0.85em;
+        font-weight: normal;
+    }
+
+    .btn-verify {
+        background: #198754;
+        color: white;
+        border: none;
+        padding: 8px 16px;
+        border-radius: 4px;
+        cursor: pointer;
+        margin-right: 8px;
+    }
+
+    .btn-verify:hover {
+        background: #157347;
+    }
+
+    .btn-flag {
+        background: #dc3545;
+        color: white;
+        border: none;
+        padding: 8px 16px;
+        border-radius: 4px;
+        cursor: pointer;
+    }
+
+    .btn-flag:hover {
+        background: #bb2d3b;
+    }
+
+    .back-link {
+        color: #0d6efd;
+        text-decoration: none;
+    }
+</style>
+
+<script>
+    function confirmDecision(btn) {
+        const remarks = document.getElementById('remarks').value.trim();
+        if (btn.value === 'flagged' && !remarks) {
+            alert('Please add remarks explaining what needs correction before flagging.');
+            return false;
+        }
+        return confirm(btn.value === 'flagged'
+            ? 'Flag this timesheet for correction?'
+            : 'Mark this timesheet as verified?');
+    }
+</script>
+{% endblock %}

--- a/timesheet/templates/verification_log.html
+++ b/timesheet/templates/verification_log.html
@@ -1,0 +1,244 @@
+{% extends 'layout.html' %}
+
+{% block body_block %}
+<div class="container">
+    <h2 class="header">Employee Corner</h2>
+    {% include 'includes/timesheet_manager_tabs.html' %}
+
+    <!-- Filters -->
+    <div class="card">
+        <div class="card-body">
+            <form method="get" class="filter-form">
+                <div class="filter-field">
+                    <label for="week">Week (any date in it)</label>
+                    <input type="date" id="week" name="week" value="{{ filter_week }}"
+                           onchange="this.form.submit()">
+                </div>
+                <div class="filter-field">
+                    <label for="status">Status</label>
+                    <select id="status" name="status" onchange="this.form.submit()">
+                        <option value="decided" {% if filter_status == 'decided' %}selected{% endif %}>Reviewed (Verified + Flagged)</option>
+                        <option value="verified" {% if filter_status == 'verified' %}selected{% endif %}>Verified</option>
+                        <option value="flagged" {% if filter_status == 'flagged' %}selected{% endif %}>Flagged</option>
+                        <option value="pending" {% if filter_status == 'pending' %}selected{% endif %}>Pending</option>
+                        <option value="all" {% if filter_status == 'all' %}selected{% endif %}>All</option>
+                    </select>
+                </div>
+                <div class="filter-field">
+                    <label for="group">Group</label>
+                    <select id="group" name="group" onchange="this.form.submit()">
+                        <option value="">All groups</option>
+                        {% for g in group_names %}
+                        <option value="{{ g }}" {% if filter_group == g %}selected{% endif %}>{{ g }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="filter-field">
+                    <label for="employee">Employee</label>
+                    <select id="employee" name="employee" onchange="this.form.submit()">
+                        <option value="">All employees</option>
+                        {% for e in employees %}
+                        <option value="{{ e.id }}" {% if filter_employee == e.id %}selected{% endif %}>{{ e.name }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="filter-field">
+                    <label>&nbsp;</label>
+                    <a href="{% url 'verification_log' %}" class="clear-link">Clear filters</a>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Log -->
+    <div class="card">
+        <div class="card-header">
+            <h5>Verification Log</h5>
+        </div>
+        <div class="card-body">
+            {% if logs %}
+            <table class="main-table">
+                <thead>
+                    <tr>
+                        <th>Week</th>
+                        <th>Employee</th>
+                        <th>Group(s)</th>
+                        <th>Verifier</th>
+                        <th>Status</th>
+                        <th>Remarks</th>
+                        <th>Reviewed On</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for log in logs %}
+                    <tr class="{% if log.status == 'flagged' %}flagged-row{% endif %}">
+                        <td>{{ log.week_start|date:"d M" }} &ndash; {{ log.week_end|date:"d M Y" }}</td>
+                        <td>{{ log.employee_name }}</td>
+                        <td>{{ log.groups|join:", "|default:"-" }}</td>
+                        <td>{{ log.verifier_name }}</td>
+                        <td>
+                            {% if log.status == 'verified' %}
+                            <span class="badge success">Verified</span>
+                            {% elif log.status == 'flagged' %}
+                            <span class="badge critical">Flagged</span>
+                            {% else %}
+                            <span class="badge warning">Pending</span>
+                            {% endif %}
+                        </td>
+                        <td class="remarks-cell">{{ log.remarks|default:"-" }}</td>
+                        <td>{{ log.verified_at|date:"d M Y"|default:"-" }}</td>
+                        <td>
+                            <a href="{% url 'verification_detail' log.id %}" class="btn-primary btn-link-style">View</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <p class="no-entries">No verifications match these filters.</p>
+            {% endif %}
+        </div>
+    </div>
+</div>
+
+<style>
+    .container {
+        padding: 20px;
+        max-width: 1200px;
+        margin: 0 auto;
+    }
+
+    .header {
+        margin-bottom: 20px;
+    }
+
+    .card {
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        margin-bottom: 20px;
+        background: white;
+    }
+
+    .card-header {
+        padding: 10px 15px;
+        background: #f8f9fa;
+        border-bottom: 1px solid #ddd;
+    }
+
+    .card-body {
+        padding: 15px;
+    }
+
+    .filter-form {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        align-items: flex-end;
+    }
+
+    .filter-field {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .filter-field label {
+        font-size: 0.85em;
+        color: #555;
+        margin-bottom: 4px;
+    }
+
+    .filter-field input,
+    .filter-field select {
+        padding: 5px 8px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+    }
+
+    .clear-link {
+        color: #0d6efd;
+        font-size: 0.9em;
+        text-decoration: none;
+        padding-bottom: 6px;
+    }
+
+    .main-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.9em;
+    }
+
+    .main-table th,
+    .main-table td {
+        padding: 8px 6px;
+        border: 1px solid #ddd;
+        text-align: left;
+        vertical-align: middle;
+    }
+
+    .main-table th {
+        background: #f8f9fa;
+        font-weight: 600;
+        white-space: nowrap;
+    }
+
+    .remarks-cell {
+        white-space: normal;
+        max-width: 280px;
+    }
+
+    .flagged-row {
+        background: #fff3f3;
+    }
+
+    .btn-primary {
+        background: #0d6efd;
+        color: white;
+        border: none;
+        padding: 5px 10px;
+        border-radius: 4px;
+        cursor: pointer;
+    }
+
+    .btn-primary:hover {
+        background: #0b5ed7;
+    }
+
+    .btn-link-style {
+        display: inline-block;
+        text-decoration: none;
+    }
+
+    .btn-link-style:hover {
+        color: white;
+        text-decoration: none;
+    }
+
+    .badge {
+        padding: 3px 8px;
+        border-radius: 3px;
+        font-size: 0.85em;
+    }
+
+    .badge.critical {
+        background: #dc3545;
+        color: white;
+    }
+
+    .badge.warning {
+        background: #ffc107;
+        color: black;
+    }
+
+    .badge.success {
+        background: #198754;
+        color: white;
+    }
+
+    .no-entries {
+        text-align: center;
+        color: #666;
+        margin: 10px 0;
+    }
+</style>
+{% endblock %}

--- a/timesheet/urls.py
+++ b/timesheet/urls.py
@@ -9,5 +9,8 @@ urlpatterns = [
     path('get-time-settings/', views.get_time_settings, name='get_time_settings'),
     path('delete-entry/', views.delete_timesheet_entry, name='delete_timesheet_entry'),
     path('get_pending_entries/', views.get_pending_entries, name='get_pending_entries'),
-    path('manage-mandatory-timesheets/', views.manage_mandatory_timesheets, name='manage_mandatory_timesheets')
+    path('manage-mandatory-timesheets/', views.manage_mandatory_timesheets, name='manage_mandatory_timesheets'),
+    path('mark-optional/', views.mark_optional, name='mark_optional_days'),
+    path('unmark-optional/', views.unmark_optional, name='unmark_optional_days'),
+    path('list-optional/', views.list_optional_days, name='list_optional_days'),
 ]

--- a/timesheet/urls.py
+++ b/timesheet/urls.py
@@ -13,4 +13,9 @@ urlpatterns = [
     path('mark-optional/', views.mark_optional, name='mark_optional_days'),
     path('unmark-optional/', views.unmark_optional, name='unmark_optional_days'),
     path('list-optional/', views.list_optional_days, name='list_optional_days'),
+    # Fixed paths must precede the <str:allocation_id> catch-all.
+    path('verifications/', views.my_verifications, name='my_verifications'),
+    path('verifications/log/', views.verification_log, name='verification_log'),
+    path('verifications/submit/', views.submit_verification, name='submit_verification'),
+    path('verifications/<str:allocation_id>/', views.verification_detail, name='verification_detail'),
 ]

--- a/timesheet/views.py
+++ b/timesheet/views.py
@@ -1,7 +1,10 @@
 import json
+import math
+import random
 from datetime import datetime, timedelta
 from typing import Dict, List, Any, Optional
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.core.serializers.json import DjangoJSONEncoder
@@ -9,7 +12,7 @@ from django.http import JsonResponse, HttpRequest
 from django.shortcuts import render, redirect
 from django.db.models import Q
 
-from accounts.database import get_user_profile_mongo, get_group_members, is_timesheet_mandatory, update_timesheet_mandatory_status
+from accounts.database import get_user_profile_mongo, get_group_members, get_groups_for_head, get_users_by_role, get_all_groups, is_timesheet_mandatory, set_timesheet_mandatory, get_non_mandatory_dates
 from accounts.roles import ROLE_HIERARCHY
 from accounts.decorators import permission_required
 from .database import (
@@ -24,9 +27,20 @@ from .database import (
     get_tds,
     delete_timesheet_entry as db_delete_timesheet_entry,
     mark_optional_days,
+    mark_period_optional,
     unmark_optional_days,
     get_optional_dates,
     get_optional_days_detail,
+    has_allocations,
+    get_last_allocation_map,
+    create_allocations,
+    get_my_allocations,
+    count_pending_verifications,
+    get_allocation,
+    decide_allocation,
+    get_verification_log,
+    get_verification_employees,
+    get_week_entries,
 )
 
 
@@ -65,6 +79,86 @@ def _target_rank(target_user_id):
     if not profile:
         return None
     return ROLE_HIERARCHY.get(profile.get('role', ''), 99)
+
+
+def _is_verifier(user) -> bool:
+    """Group Heads and Super Group Heads receive weekly verification allocations."""
+    return is_group_head(user) or is_super_group_head(user)
+
+
+def _can_see_all_logs(user) -> bool:
+    """Super Group Head / Super Admin / superuser oversee every verification."""
+    return is_super_group_head(user) or is_admin(user) or user.is_superuser
+
+
+def _previous_week_start():
+    """Monday (midnight) of the most recently completed Mon-Sat week."""
+    today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    return today - timedelta(days=today.weekday()) - timedelta(days=7)
+
+
+def _ensure_weekly_allocation(user):
+    """Lazily create this verifier's random sample for the previous completed week.
+
+    Runs on every My Verifications load; the has_allocations check plus the unique
+    index behind create_allocations make it idempotent. Only the immediately
+    previous week is generated - older pending allocations never expire, so a week
+    the verifier never opened is skipped deliberately, not lost.
+    """
+    week_start = _previous_week_start()
+    if week_start < settings.TIMESHEET_START_DATE:
+        return
+    if has_allocations(user.id, week_start):
+        return
+
+    if is_super_group_head(user):
+        pool_ids = get_users_by_role('Group Head')
+        verifier_role = 'Super Group Head'
+    elif is_group_head(user):
+        pool_ids = get_group_members(str(user.id))
+        verifier_role = 'Group Head'
+    else:
+        return
+    if not pool_ids:
+        return
+
+    week_end = week_start + timedelta(days=5)
+    User = get_user_model()
+    candidates = []
+    for member in User.objects.filter(id__in=pool_ids, is_active=True).exclude(id=user.id):
+        profile = get_user_profile_mongo(member.id)
+        if not profile:
+            continue
+        if not is_timesheet_mandatory(profile):
+            continue  # not required to fill timesheets -> nothing to verify
+        effective_date = profile.get('effective_date')
+        if effective_date and effective_date > week_end:
+            continue  # joined after the week being verified
+        candidates.append((member, profile))
+    if not candidates:
+        return
+
+    k = min(len(candidates), max(1, math.ceil(0.25 * len(candidates))))
+    last_allocated = get_last_allocation_map(user.id, [str(m.id) for m, _ in candidates])
+    random.shuffle(candidates)
+    # Stable sort after the shuffle: least-recently-reviewed first, random tie-break.
+    candidates.sort(key=lambda c: last_allocated.get(str(c[0].id), datetime.min))
+
+    create_allocations([
+        {
+            'week_start': week_start,
+            'week_end': week_end,
+            'employee_id': str(member.id),
+            'employee_name': member.get_full_name() or member.username,
+            'employee_role': profile.get('role', ''),
+            'verifier_id': str(user.id),
+            'verifier_name': user.get_full_name() or user.username,
+            'verifier_role': verifier_role,
+            'groups': profile.get('groups', []),
+            'allocation_method': 'random_lru',
+        }
+        for member, profile in candidates[:k]
+    ])
 
 
 def _expand_optional_dates(mode, request):
@@ -150,11 +244,10 @@ def fill_timesheet(request: HttpRequest):
 
         if is_timesheet_mandatory(user_profile):
             user_start_date = user_profile.get('effective_date')
-            optional_set = get_optional_dates(
-                request.user.id,
-                user_start_date if user_start_date else today - timedelta(days=14),
-                today,
-            )
+            window_start = user_start_date if user_start_date else today - timedelta(days=14)
+            optional_set = get_optional_dates(request.user.id, window_start, today)
+            # Days in a past non-mandatory period stay excused even after the user is mandatory again.
+            optional_set |= get_non_mandatory_dates(user_profile, window_start, today)
             days_checked = 0
             days_with_pending = 0
             check_date = today - timedelta(days=1)
@@ -223,6 +316,7 @@ def fill_timesheet(request: HttpRequest):
         'user_effective_date': user_effective_date,
         'today': today,
         'client_names': get_client_names(),
+        'pending_verification_count': count_pending_verifications(request.user.id) if _is_verifier(request.user) else 0,
     }
     return render(request, 'fill_timesheet.html', context)
 
@@ -303,6 +397,7 @@ def get_pending_entries(request: HttpRequest) -> JsonResponse:
         user_start_date if user_start_date else today - timedelta(days=7)
     )
     optional_set = get_optional_dates(request.user.id, start_check_date, today)
+    optional_set |= get_non_mandatory_dates(user_profile, start_check_date, today)
 
     # Get all timesheet entries for the date range in one query to reduce database calls
     from .database import db
@@ -487,6 +582,13 @@ def employee_corner(request: HttpRequest):
     for doc in optional_docs:
         optional_by_user.setdefault(doc['user_id'], set()).add(doc['date'])
 
+    # Fold each user's non-mandatory periods into their optional set so they are not
+    # counted as pending/critical while (or after) being excused from timesheets.
+    for user in all_users:
+        non_mandatory = get_non_mandatory_dates(user_profiles[user.id], min_start_date, today)
+        if non_mandatory:
+            optional_by_user.setdefault(str(user.id), set()).update(non_mandatory)
+
     can_mark = _can_mark_optional(request)
     actor_rank = _actor_rank(request)
 
@@ -578,9 +680,12 @@ def employee_corner(request: HttpRequest):
         'selected_date': selected_date,
         'is_super_group_head': is_super_group_head(request.user),
         'can_mark_optional': can_mark,
-        'today': datetime.now()
+        'today': datetime.now(),
+        'show_manager_tabs': _is_verifier(request.user) or _can_see_all_logs(request.user),
+        'pending_verification_count': count_pending_verifications(request.user.id) if _is_verifier(request.user) else 0,
+        'active_tab': 'overview',
     }
-    
+
     return render(request, 'employee_corner.html', context)
 
 @permission_required('timesheet', 'view')
@@ -638,8 +743,19 @@ def manage_mandatory_timesheets(request: HttpRequest):
         
         if current_rank >= target_rank:
             return JsonResponse({'status': 'error', 'message': 'Permission denied'}, status=403)
-            
-        update_timesheet_mandatory_status(target_user_id, status)
+
+        changed = set_timesheet_mandatory(
+            target_user_id, status, request.user.id, request.user.get_full_name()
+        )
+        # Switching off marks the user's whole timesheet history optional (see edit_user).
+        if changed and not status:
+            start = target_profile.get('effective_date') or settings.TIMESHEET_START_DATE
+            today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+            mark_period_optional(
+                target_user_id, start, today,
+                reason='TIMESHEET NOT MANDATORY',
+                marked_by=request.user.id, marked_by_name=request.user.get_full_name(),
+            )
         return JsonResponse({'status': 'success', 'message': 'Mandatory timesheet setting updated successfully.'})
 
     # GET request
@@ -768,3 +884,206 @@ def list_optional_days(request: HttpRequest) -> JsonResponse:
             for d in details
         ],
     })
+
+
+@permission_required('timesheet', 'view')
+def my_verifications(request: HttpRequest):
+    """Verifier's weekly random allocations: pending reviews plus recent decisions."""
+    if not (_is_verifier(request.user) or _can_see_all_logs(request.user)):
+        return redirect('permission_denied')
+
+    allocations = []
+    if _is_verifier(request.user):
+        _ensure_weekly_allocation(request.user)
+        allocations = get_my_allocations(request.user.id)
+
+    pending = [a for a in allocations if a['status'] == 'pending']
+    reviewed = [a for a in allocations if a['status'] != 'pending']
+    context = {
+        'pending_allocations': pending,
+        'reviewed_allocations': reviewed[:20],
+        'is_verifier': _is_verifier(request.user),
+        'show_manager_tabs': True,
+        'pending_verification_count': len(pending),
+        'active_tab': 'verifications',
+    }
+    return render(request, 'my_verifications.html', context)
+
+
+@permission_required('timesheet', 'view')
+def verification_detail(request: HttpRequest, allocation_id):
+    """Day-by-day view of an allocated employee-week, with verify/flag actions."""
+    allocation = get_allocation(allocation_id)
+    if not allocation:
+        messages.error(request, 'Verification record not found.')
+        return redirect('my_verifications')
+
+    is_assigned = str(request.user.id) == allocation['verifier_id']
+    is_groups_head_of_employee = (
+        is_group_head(request.user)
+        and allocation['employee_id'] in get_group_members(str(request.user.id))
+    )
+    if not (is_assigned or _can_see_all_logs(request.user) or is_groups_head_of_employee):
+        return redirect('permission_denied')
+
+    can_decide = allocation['status'] == 'pending' and (
+        is_assigned or is_admin(request.user) or request.user.is_superuser
+    )
+
+    profile = get_user_profile_mongo(allocation['employee_id']) or {}
+    default_time_in = profile.get('time_in', '09:00')
+    default_time_out = profile.get('time_out', '18:00')
+    effective_date = profile.get('effective_date')
+
+    week_start = allocation['week_start']
+    week_end = allocation['week_end']
+    entries_by_day = get_week_entries(allocation['employee_id'], week_start)
+    optional_by_date = {
+        d['date']: d
+        for d in get_optional_days_detail(allocation['employee_id'], week_start, week_end)
+    }
+    # Days the employee was non-mandatory that week are optional even without an explicit mark.
+    non_mandatory_dates = get_non_mandatory_dates(profile, week_start, week_end)
+
+    day_rows = []
+    week_total = 0.0
+    week_pending = 0.0
+    for offset in range(6):  # Mon..Sat; Sundays are not working days anywhere in the app
+        day = week_start + timedelta(days=offset)
+        day_entries = entries_by_day.get(day.strftime('%Y-%m-%d'), [])
+        if day_entries:
+            time_in = day_entries[0].get('time_in', default_time_in)
+            time_out = day_entries[0].get('time_out', default_time_out)
+        else:
+            time_in = default_time_in
+            time_out = default_time_out
+        standard_hours = (
+            datetime.strptime(time_out, '%H:%M') - datetime.strptime(time_in, '%H:%M')
+        ).seconds / 3600
+
+        day_total = sum(entry.get('hours', 0) for entry in day_entries)
+        optional = optional_by_date.get(day)
+        non_mandatory = day in non_mandatory_dates
+        before_joining = bool(effective_date and day < effective_date)
+        if optional or non_mandatory or before_joining:
+            pending = 0.0
+        else:
+            pending = standard_hours - day_total
+
+        day_rows.append({
+            'date': day,
+            'entries': day_entries,
+            'standard_hours': 0 if before_joining else standard_hours,
+            'total_hours': round(day_total, 2),
+            'pending_hours': round(pending, 2),
+            'optional': optional,
+            'non_mandatory': non_mandatory and not optional,
+            'before_joining': before_joining,
+        })
+        week_total += day_total
+        week_pending += pending
+
+    context = {
+        'allocation': allocation,
+        'day_rows': day_rows,
+        'week_total': round(week_total, 2),
+        'week_pending': round(week_pending, 2),
+        'days_with_entries': sum(1 for row in day_rows if row['entries']),
+        'can_decide': can_decide,
+        'show_manager_tabs': True,
+        'pending_verification_count': count_pending_verifications(request.user.id) if _is_verifier(request.user) else 0,
+        'active_tab': 'verifications',
+    }
+    return render(request, 'verification_detail.html', context)
+
+
+@permission_required('timesheet', 'change')
+def submit_verification(request: HttpRequest):
+    """Record a Verified / Flagged decision on a pending allocation."""
+    if request.method != 'POST':
+        return redirect('my_verifications')
+
+    allocation_id = request.POST.get('allocation_id')
+    action = request.POST.get('action')
+    remarks = (request.POST.get('remarks') or '').strip()
+
+    allocation = get_allocation(allocation_id)
+    if not allocation:
+        messages.error(request, 'Verification record not found.')
+        return redirect('my_verifications')
+
+    if action not in ('verified', 'flagged'):
+        messages.error(request, 'Invalid verification action.')
+        return redirect('verification_detail', allocation_id=allocation_id)
+    if action == 'flagged' and not remarks:
+        messages.error(request, 'Remarks are required when flagging a timesheet for correction.')
+        return redirect('verification_detail', allocation_id=allocation_id)
+
+    bypass = is_admin(request.user) or request.user.is_superuser
+    if str(request.user.id) != allocation['verifier_id'] and not bypass:
+        return redirect('permission_denied')
+
+    if decide_allocation(allocation_id, request.user.id, action, remarks, bypass_verifier=bypass):
+        outcome = 'verified' if action == 'verified' else 'flagged for correction'
+        messages.success(
+            request,
+            f"{allocation['employee_name']}'s timesheet for the week of "
+            f"{allocation['week_start'].strftime('%d-%m-%Y')} was {outcome}."
+        )
+    else:
+        messages.warning(request, 'This timesheet was already reviewed.')
+    return redirect('my_verifications')
+
+
+@permission_required('timesheet', 'view')
+def verification_log(request: HttpRequest):
+    """Review log of verified/flagged timesheets, scoped by role."""
+    if _can_see_all_logs(request.user):
+        scope = None
+        group_names = [g['Group_name'] for g in get_all_groups()]
+    elif is_group_head(request.user):
+        # Own decisions plus anything about the GH's current group members.
+        scope = {'$or': [
+            {'verifier_id': str(request.user.id)},
+            {'employee_id': {'$in': get_group_members(str(request.user.id))}},
+        ]}
+        group_names = get_groups_for_head(str(request.user.id))
+    else:
+        return redirect('permission_denied')
+
+    week_raw = request.GET.get('week', '')
+    status = request.GET.get('status', 'decided')
+    group = request.GET.get('group', '')
+    employee = request.GET.get('employee', '')
+
+    week_start = None
+    if week_raw:
+        try:
+            anchor = datetime.strptime(week_raw, '%Y-%m-%d')
+            week_start = (anchor - timedelta(days=anchor.weekday())).replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
+        except ValueError:
+            week_raw = ''
+
+    logs = get_verification_log(
+        scope,
+        week_start=week_start,
+        status=status,
+        group=group or None,
+        employee_id=employee or None,
+    )
+
+    context = {
+        'logs': logs,
+        'group_names': group_names,
+        'employees': get_verification_employees(scope),
+        'filter_week': week_start.strftime('%Y-%m-%d') if week_start else '',
+        'filter_status': status,
+        'filter_group': group,
+        'filter_employee': employee,
+        'show_manager_tabs': True,
+        'pending_verification_count': count_pending_verifications(request.user.id) if _is_verifier(request.user) else 0,
+        'active_tab': 'log',
+    }
+    return render(request, 'verification_log.html', context)

--- a/timesheet/views.py
+++ b/timesheet/views.py
@@ -23,6 +23,10 @@ from .database import (
     get_proceedings,
     get_tds,
     delete_timesheet_entry as db_delete_timesheet_entry,
+    mark_optional_days,
+    unmark_optional_days,
+    get_optional_dates,
+    get_optional_days_detail,
 )
 
 
@@ -39,6 +43,71 @@ def is_super_group_head(user) -> bool:
 def is_admin(user) -> bool:
     """Check if user is a Super Admin."""
     return user.groups.filter(name='Super Admin').exists()
+
+
+def _can_mark_optional(request) -> bool:
+    """Only Super Group Head / Super Admin (or superuser) may mark optional days."""
+    return is_super_group_head(request.user) or is_admin(request.user) or request.user.is_superuser
+
+
+def _actor_rank(request) -> int:
+    """Rank of the requesting user (lower = higher authority); 0 for admin/superuser."""
+    if is_admin(request.user) or request.user.is_superuser:
+        return 0
+    profile = get_user_profile_mongo(request.user.id)
+    role = profile.get('role', '') if profile else ''
+    return ROLE_HIERARCHY.get(role, 99)
+
+
+def _target_rank(target_user_id):
+    """Rank of a target user from their Mongo profile, or None if the profile is missing."""
+    profile = get_user_profile_mongo(target_user_id)
+    if not profile:
+        return None
+    return ROLE_HIERARCHY.get(profile.get('role', ''), 99)
+
+
+def _expand_optional_dates(mode, request):
+    """Build the list of working-day midnight datetimes (Sundays skipped) for a mode.
+
+    mode 'day' -> POST['date']; 'range' -> POST['start_date']..POST['end_date'] inclusive;
+    'week' -> Mon..Sat of the week containing POST['week_start'] (or POST['date']).
+    Returns (dates, error_message).
+    """
+    def _parse(name):
+        raw = request.POST.get(name)
+        if not raw:
+            return None
+        return datetime.strptime(raw, '%Y-%m-%d').replace(hour=0, minute=0, second=0, microsecond=0)
+
+    dates = []
+    if mode == 'day':
+        d = _parse('date')
+        if not d:
+            return None, 'A date is required.'
+        if d.weekday() != 6:  # skip Sunday
+            dates.append(d)
+    elif mode == 'range':
+        start = _parse('start_date')
+        end = _parse('end_date')
+        if not start or not end:
+            return None, 'Start and end dates are required.'
+        if end < start:
+            return None, 'End date cannot be before start date.'
+        cur = start
+        while cur <= end:
+            if cur.weekday() != 6:  # skip Sundays
+                dates.append(cur)
+            cur += timedelta(days=1)
+    elif mode == 'week':
+        anchor = _parse('week_start') or _parse('date')
+        if not anchor:
+            return None, 'A date within the week is required.'
+        monday = anchor - timedelta(days=anchor.weekday())
+        dates = [monday + timedelta(days=i) for i in range(6)]  # Mon..Sat
+    else:
+        return None, 'Invalid selection mode.'
+    return dates, None
 
 # Create your views here.
 
@@ -81,6 +150,11 @@ def fill_timesheet(request: HttpRequest):
 
         if is_timesheet_mandatory(user_profile):
             user_start_date = user_profile.get('effective_date')
+            optional_set = get_optional_dates(
+                request.user.id,
+                user_start_date if user_start_date else today - timedelta(days=14),
+                today,
+            )
             days_checked = 0
             days_with_pending = 0
             check_date = today - timedelta(days=1)
@@ -92,7 +166,7 @@ def fill_timesheet(request: HttpRequest):
                     if user_start_date and check_date < user_start_date:
                         break
                         
-                    if check_date.weekday() != 6:  # Not Sunday
+                    if check_date.weekday() != 6 and check_date not in optional_set:  # Not Sunday, not optional
                         daily_entries = get_user_timesheets(request.user.id, check_date)
                         if daily_entries:
                             # Check if the last entry of the day has pending_hours set to 0
@@ -228,7 +302,8 @@ def get_pending_entries(request: HttpRequest) -> JsonResponse:
     start_check_date = (
         user_start_date if user_start_date else today - timedelta(days=7)
     )
-    
+    optional_set = get_optional_dates(request.user.id, start_check_date, today)
+
     # Get all timesheet entries for the date range in one query to reduce database calls
     from .database import db
     all_entries = list(db.timesheetMaster.find({
@@ -250,7 +325,7 @@ def get_pending_entries(request: HttpRequest) -> JsonResponse:
         check_date = today - timedelta(days=days_back)
         if user_start_date and check_date < user_start_date:
             break
-        if check_date.weekday() != 6:  # Skip Sundays
+        if check_date.weekday() != 6 and check_date not in optional_set:  # Skip Sundays + optional
             date_str = check_date.strftime('%Y-%m-%d')
             daily_entries = entries_by_date.get(date_str, [])
             
@@ -402,12 +477,25 @@ def employee_corner(request: HttpRequest):
         if date_str not in entries_by_user_date[user_id]:
             entries_by_user_date[user_id][date_str] = []
         entries_by_user_date[user_id][date_str].append(entry)
-    
+
+    # Prefetch optional days for all visible users in one query, grouped per user.
+    optional_docs = db.optionalDayMaster.find({
+        'user_id': {'$in': user_ids},
+        'date': {'$gte': min_start_date, '$lte': today}
+    }, {'_id': 0, 'user_id': 1, 'date': 1})
+    optional_by_user = {}
+    for doc in optional_docs:
+        optional_by_user.setdefault(doc['user_id'], set()).add(doc['date'])
+
+    can_mark = _can_mark_optional(request)
+    actor_rank = _actor_rank(request)
+
     for user in all_users:
         user_profile = user_profiles[user.id]
         default_time_in = user_profile.get('time_in', '09:00')
         default_time_out = user_profile.get('time_out', '18:00')
         user_start_date = user_profile.get('effective_date')
+        user_optional = optional_by_user.get(str(user.id), set())
         
         # Get timesheet entries for selected date
         selected_date_str = selected_date.strftime('%Y-%m-%d')
@@ -428,7 +516,7 @@ def employee_corner(request: HttpRequest):
         standard_hours = (time_out_obj - time_in_obj).seconds / 3600
         
         daily_total = sum(entry.get('hours', 0) for entry in daily_entries)
-        pending_hours = standard_hours - daily_total if selected_date.weekday() != 6 else 0
+        pending_hours = standard_hours - daily_total if (selected_date.weekday() != 6 and selected_date not in user_optional) else 0
         
         # Calculate pending days from user's start date or last 7 days, whichever is more recent
         start_check_date = user_start_date if user_start_date else today - timedelta(days=7)
@@ -439,7 +527,7 @@ def employee_corner(request: HttpRequest):
         user_entries = entries_by_user_date.get(str(user.id), {})
         
         while check_date >= start_check_date:
-            if check_date.weekday() != 6:  # Skip Sunday
+            if check_date.weekday() != 6 and check_date not in user_optional:  # Skip Sunday + optional
                 check_date_str = check_date.strftime('%Y-%m-%d')
                 day_entries = user_entries.get(check_date_str, [])
                 
@@ -465,7 +553,8 @@ def employee_corner(request: HttpRequest):
         
         # Serialize timesheet entries for JavaScript
         serialized_entries = json.dumps(daily_entries, cls=DjangoJSONEncoder)
-        
+
+        target_rank_val = ROLE_HIERARCHY.get(user_profile.get('role', ''), 99) if user_profile else 99
         user_data.append({
             'user': user,
             'timesheet_entries': daily_entries,
@@ -476,7 +565,9 @@ def employee_corner(request: HttpRequest):
             'is_critical': days_with_pending >= 7,
             'days_with_pending': days_with_pending,
             'total_pending_days': total_pending_days,
-            'start_date': start_check_date.strftime('%Y-%m-%d') if start_check_date else None
+            'start_date': start_check_date.strftime('%Y-%m-%d') if start_check_date else None,
+            'can_mark_optional': can_mark and actor_rank < target_rank_val,
+            'optional_days': sorted(d.strftime('%Y-%m-%d') for d in user_optional),
         })
     
     # Sort users by pending hours and critical status
@@ -486,6 +577,7 @@ def employee_corner(request: HttpRequest):
         'user_data': user_data,
         'selected_date': selected_date,
         'is_super_group_head': is_super_group_head(request.user),
+        'can_mark_optional': can_mark,
         'today': datetime.now()
     }
     
@@ -581,3 +673,98 @@ def manage_mandatory_timesheets(request: HttpRequest):
             })
             
     return render(request, 'manage_mandatory_timesheets.html', {'users': manageable_users, 'current_role': current_role})
+
+
+@permission_required('timesheet', 'view')
+def mark_optional(request: HttpRequest) -> JsonResponse:
+    """Mark an employee's day(s) as optional so they no longer count as pending."""
+    if request.method != 'POST':
+        return JsonResponse({'status': 'error', 'message': 'Invalid request method.'}, status=405)
+    if not _can_mark_optional(request):
+        return JsonResponse({'status': 'error', 'message': 'Permission denied'}, status=403)
+
+    target_user_id = request.POST.get('user_id')
+    target_rank = _target_rank(target_user_id)
+    if target_rank is None:
+        return JsonResponse({'status': 'error', 'message': 'User profile not found'}, status=404)
+    if _actor_rank(request) >= target_rank:  # strictly lower-rank targets only (no self/peers)
+        return JsonResponse({'status': 'error', 'message': 'Permission denied'}, status=403)
+
+    dates, error = _expand_optional_dates(request.POST.get('mode', 'day'), request)
+    if error:
+        return JsonResponse({'status': 'error', 'message': error}, status=400)
+    if not dates:
+        return JsonResponse({'status': 'error', 'message': 'No working days selected.'}, status=400)
+
+    count = mark_optional_days(
+        target_user_id, dates,
+        reason=request.POST.get('reason', ''),
+        marked_by=request.user.id,
+        marked_by_name=request.user.get_full_name(),
+    )
+    messages.success(request, f'Marked {count} day(s) as optional.')
+    return JsonResponse({'status': 'success', 'marked': count})
+
+
+@permission_required('timesheet', 'view')
+def unmark_optional(request: HttpRequest) -> JsonResponse:
+    """Remove optional-day mark(s) for an employee (single date or inclusive range)."""
+    if request.method != 'POST':
+        return JsonResponse({'status': 'error', 'message': 'Invalid request method.'}, status=405)
+    if not _can_mark_optional(request):
+        return JsonResponse({'status': 'error', 'message': 'Permission denied'}, status=403)
+
+    target_user_id = request.POST.get('user_id')
+    target_rank = _target_rank(target_user_id)
+    if target_rank is None:
+        return JsonResponse({'status': 'error', 'message': 'User profile not found'}, status=404)
+    if _actor_rank(request) >= target_rank:
+        return JsonResponse({'status': 'error', 'message': 'Permission denied'}, status=403)
+
+    single = request.POST.get('date')
+    if single:
+        dates = [datetime.strptime(single, '%Y-%m-%d')]
+    else:
+        start = request.POST.get('start_date')
+        end = request.POST.get('end_date')
+        if not start or not end:
+            return JsonResponse({'status': 'error', 'message': 'A date or date range is required.'}, status=400)
+        start_d = datetime.strptime(start, '%Y-%m-%d')
+        end_d = datetime.strptime(end, '%Y-%m-%d')
+        dates = []
+        cur = start_d
+        while cur <= end_d:
+            dates.append(cur)
+            cur += timedelta(days=1)
+
+    removed = unmark_optional_days(target_user_id, dates)
+    messages.success(request, f'Removed optional mark from {removed} day(s).')
+    return JsonResponse({'status': 'success', 'removed': removed})
+
+
+@permission_required('timesheet', 'view')
+def list_optional_days(request: HttpRequest) -> JsonResponse:
+    """List an employee's optional days for the Employee Corner unmark panel."""
+    if not _can_mark_optional(request):
+        return JsonResponse({'status': 'error', 'message': 'Permission denied'}, status=403)
+
+    target_user_id = request.GET.get('user_id')
+    target_rank = _target_rank(target_user_id)
+    if target_rank is None:
+        return JsonResponse({'status': 'error', 'message': 'User profile not found'}, status=404)
+    if _actor_rank(request) >= target_rank:
+        return JsonResponse({'status': 'error', 'message': 'Permission denied'}, status=403)
+
+    today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    details = get_optional_days_detail(target_user_id, today - timedelta(days=90), today + timedelta(days=90))
+    return JsonResponse({
+        'status': 'success',
+        'optional_days': [
+            {
+                'date': d['date'].strftime('%Y-%m-%d'),
+                'reason': d.get('reason', ''),
+                'marked_by_name': d.get('marked_by_name', ''),
+            }
+            for d in details
+        ],
+    })


### PR DESCRIPTION
## Summary

Adds the ability for **Super Group Head & Super Admin** users to mark an employee's specific days/weeks as **optional**, so those days stop counting as "pending/unfilled" everywhere — including **lifting the mandatory-fill block** that otherwise prevents an employee from filling today's timesheet. Managed **inline in the Employee Corner** dashboard. Fully reversible.

### Why
Previously the only special-cased day was Sunday. Legitimate gaps (approved leave, field work, onboarding, office holidays) kept nagging as pending forever and could hard-block mandatory users from filling their timesheet, with no way for a manager to waive them.

## What changed

**Data model** — new Mongo collection `optionalDayMaster`, one doc per `(user_id, date)`:
`{ user_id, date (midnight), reason, marked_by, marked_by_name, created_at }`. Idempotent upsert; per-day storage so the day-by-day pending loops just do an O(1) set-membership check.

**`timesheet/database.py`** — `mark_optional_days`, `unmark_optional_days`, `get_optional_dates` (prefetch set), `get_optional_days_detail`, with `_normalize_date` matching the existing midnight-datetime storage.

**`timesheet/views.py` + `urls.py`** — three rank-gated AJAX endpoints:
- `mark_optional` (POST): modes `day` / `range` / `week` (+ optional reason); expands to working days (Sundays skipped).
- `unmark_optional` (POST): single date or inclusive range.
- `list_optional_days` (GET).
Access is **Super Group Head / Super Admin / superuser only**, and the target must be of **strictly lower rank** (no self, no peers) — mirroring the `manage_mandatory_timesheets` pattern. CSRF uses the session-backed `csrfmiddlewaretoken` (this project runs `CSRF_USE_SESSIONS=True`). On success the endpoints set `messages.success(...)`.

**Pending exclusion at all three sites** — optional days are skipped right beside the existing Sunday check:
- the `fill_timesheet` mandatory block (lifts the block),
- `get_pending_entries` (employee's own 7-day card),
- `employee_corner` (per-row `pending_hours`, `days_with_pending`, `is_critical`/warning badges, and sort all recompute automatically).

**Employee Corner UI** (`employee_corner.html`) — a per-row **Mark Optional** button (rendered only for SGH/SA on strictly-lower-rank rows) opens a modal: single day / date range / whole-week selection + reason, and a list of the employee's current optional days with **Unmark**. AJAX → `location.reload()`, and the centralized flash banner (already on `main`) confirms the result.

## Behavior / edge cases
- Sundays are never marked (auto-skipped in range/week expansion). Marking is **reversible**. Timesheet entries are **never modified**. Future / already-filled / pre-effective-date days are harmless no-ops. Re-marking is idempotent (updates reason). Group Heads can view Employee Corner but get no mark action; peer/self/higher-rank targets are rejected with JSON 403.

## Testing
- `python manage.py check` passes (only pre-existing duplicate-templatetag warnings).
- Backend files parse; templates compile via the loader.
- **Isolated DB smoke test** against a throwaway `HMD_test` Mongo database (no real-data risk) verifying: midnight normalization (non-midnight inputs match), idempotent upsert de-dup, reason update/uppercasing, `get_optional_dates` set contents, and unmark — all pass.
- Not yet exercised end-to-end in a running browser (clicking through Employee Corner as an SGH).

## Notes
- Branched off the latest `main` (PR #14/#15 already merged), so it reuses the centralized flash messaging. Recommend adding a manual Mongo unique index on `optionalDayMaster (user_id, date)` (the repo creates indexes out-of-band); the upsert is correct without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
